### PR TITLE
update typings

### DIFF
--- a/src/ThingIFError.ts
+++ b/src/ThingIFError.ts
@@ -1,4 +1,3 @@
-/// <reference path="../typings/modules/make-error-cause/index.d.ts" />
 import * as KiiUtil from './internal/KiiUtilities'
 import * as makeErrorCause from 'make-error-cause'
 

--- a/typings.json
+++ b/typings.json
@@ -1,16 +1,15 @@
 {
   "dependencies": {
-    "es6-promise": "registry:npm/es6-promise#3.0.0+20160211003958",
-    "make-error-cause": "npm:make-error-cause",
-    "nock": "registry:npm/nock#0.7.0+20160211003958",
+    "es6-promise": "registry:npm/es6-promise#3.0.0+20160723033700",
+    "nock": "registry:npm/nock#0.7.0+20160723033700",
     "popsicle": "npm:popsicle"
   },
   "globalDevDependencies": {
     "chai": "registry:dt/chai#3.4.0+20160601211834",
-    "mocha": "registry:env/mocha#2.2.5+20160321223601",
+    "mocha": "registry:dt/mocha#2.2.5+20160720003353",
     "simple-mock": "registry:dt/simple-mock#0.0.0+20160316155526"
   },
   "globalDependencies": {
-    "node": "registry:dt/node#6.0.0+20160621231320"
+    "node": "registry:env/node#6.0.0+20160723033700"
   }
 }


### PR DESCRIPTION
When executing `typings install`, there ware always has complains from typings for deprecated typed definition,  like

  ```
 typings WARN deprecated 7/23/2016: "registry:npm/es6-promise#3.0.0+20160211003958" is deprecated (updated, replaced or removed)
typings WARN deprecated 7/23/2016: "registry:env/mocha#2.2.5+20160321223601" is deprecated (updated, replaced or removed)
typings WARN deprecated 7/23/2016: "registry:npm/nock#0.7.0+20160211003958" is deprecated (updated, replaced or removed)
typings WARN deprecated 8/2/2016: "registry:dt/node#6.0.0+20160621231320" is deprecated (updated, replaced or removed)
  ```
This PR is to fix the warnings