### PR TITLE
Validate issuerID of CommandTriggerRequest

### DIFF
--- a/src/APIAuthor.ts
+++ b/src/APIAuthor.ts
@@ -163,6 +163,7 @@ export class APIAuthor {
      *
      * @param {TypedID} target TypedID of target, only Types.THING is supported now.
      * @param {Object} requestObject Necessary fields for new command trigger.
+     *   IssuerID is required in requestObject.
      * @param {onCompletion} [function] Callback function when completed
      * @return {Promise} promise object
      * @example

--- a/src/ThingIFAPI.ts
+++ b/src/ThingIFAPI.ts
@@ -250,6 +250,7 @@ export class ThingIFAPI {
      * `target` property and commandTarget in requestObject must belong to same owner.
      *
      * @param {Object} requestObject Necessary fields for new command trigger.
+     *   `_owner` property is used as IssuerID. So even if IssuerID is provided in requestObject, it will be ignored.
      * @param {onCompletion} [function] Callback function when completed
      * @return {Promise} promise object
      * @example
@@ -272,6 +273,11 @@ export class ThingIFAPI {
                 reject(new ThingIFError(Errors.IlllegalStateError, "target is null, please onboard first"));
                 return;
             }
+            if(!this._owner){
+                reject(new ThingIFError(Errors.IlllegalStateError, "_owner is null when ThingIFAPI is initialized"));
+                return;
+            }
+            requestObject.issuerID = this._owner;
             (new TriggerOps(this._au, this._target)).postCommandTrigger(requestObject)
             .then((trigger)=>{
                 resolve(trigger);
@@ -384,6 +390,11 @@ export class ThingIFAPI {
                 reject(new ThingIFError(Errors.IlllegalStateError, "target is null, please onboard first"));
                 return;
             }
+            if(!this._owner){
+                reject(new ThingIFError(Errors.IlllegalStateError, "_owner is null when ThingIFAPI is initialized"));
+                return;
+            }
+            requestObject.issuerID = this._owner;
             (new TriggerOps(this._au, this._target)).patchCommandTrigger(triggerID, requestObject)
             .then((trigger)=>{
                 resolve(trigger);

--- a/src/ops/TriggerOps.ts
+++ b/src/ops/TriggerOps.ts
@@ -52,6 +52,11 @@ export default class TriggerOps extends BaseOp {
                 reject(new ThingIFError(Errors.ArgumentError, "commandTarget is null"));
                 return;
             }
+
+            if (!requestObject.issuerID) {
+                reject(new ThingIFError(Errors.ArgumentError, "issuerID is null"));
+                return;
+            }
             var command = new Command(
                 requestObject.commandTarget,
                 requestObject.issuerID,
@@ -178,6 +183,11 @@ export default class TriggerOps extends BaseOp {
 
             if (!requestObject.commandTarget) {
                 reject(new ThingIFError(Errors.ArgumentError, "commandTarget is null"));
+                return;
+            }
+
+            if (!requestObject.issuerID) {
+                reject(new ThingIFError(Errors.ArgumentError, "issuerID is null"));
                 return;
             }
 

--- a/test/large/ThingIFAPITriggerTest.ts
+++ b/test/large/ThingIFAPITriggerTest.ts
@@ -70,7 +70,7 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
 
                 var condition = new thingIFSDK.Condition(new thingIFSDK.Equals("power", "false"));
                 var statePredicate = new thingIFSDK.StatePredicate(condition, thingIFSDK.TriggersWhen.CONDITION_CHANGED);
-                var request = new thingIFSDK.CommandTriggerRequest(schema, schemaVersion, targetID, actions, statePredicate, issuerID);
+                var request = new thingIFSDK.CommandTriggerRequest(schema, schemaVersion, targetID, actions, statePredicate);
 
                 // 1. create command trigger with StatePredicate
                 api.postCommandTrigger(request).then((trigger:any)=>{
@@ -85,12 +85,12 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                     expect(trigger.command.schemaVersion).to.equal(schemaVersion);
                     expect(trigger.command.actions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(targetID);
-                    expect(trigger.command.issuerID).to.deep.equal(issuerID);
+                    expect(trigger.command.issuerID.toString()).to.deep.equal(issuerID.toString());
                     expect(trigger.serverCode).to.be.null;
 
                     // 2. create command trigger with SchedulePredicate
                     var schedulePredicate = new thingIFSDK.SchedulePredicate("0 12 1 * *");
-                    request = new thingIFSDK.CommandTriggerRequest(schema, schemaVersion, targetID, actions, schedulePredicate, issuerID);
+                    request = new thingIFSDK.CommandTriggerRequest(schema, schemaVersion, targetID, actions, schedulePredicate);
                     // Admin token is needed when allowCreateTaskByPrincipal=false
                     api._au._token = adminToken;
                     return api.postCommandTrigger(request);
@@ -103,7 +103,7 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                     expect(trigger.command.schemaVersion).to.equal(schemaVersion);
                     expect(trigger.command.actions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(targetID);
-                    expect(trigger.command.issuerID).to.deep.equal(issuerID);
+                    expect(trigger.command.issuerID.toString()).to.deep.equal(issuerID.toString());
                     expect(trigger.serverCode).to.be.null;
 
                     // 3. disable trigger
@@ -116,7 +116,7 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                     expect(trigger.command.schemaVersion).to.equal(schemaVersion);
                     expect(trigger.command.actions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(targetID);
-                    expect(trigger.command.issuerID).to.deep.equal(issuerID);
+                    expect(trigger.command.issuerID.toString()).to.deep.equal(issuerID.toString());
                     expect(trigger.serverCode).to.be.null;
 
                     // 4. list triggers
@@ -137,7 +137,7 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                             expect(trigger.command.schemaVersion).to.equal(schemaVersion);
                             expect(trigger.command.actions).to.deep.equal(actions);
                             expect(trigger.command.targetID).to.deep.equal(targetID);
-                            expect(trigger.command.issuerID).to.deep.equal(issuerID);
+                            expect(trigger.command.issuerID.toString()).to.deep.equal(issuerID.toString());
                             expect(trigger.serverCode).to.be.null;
                         } else if (trigger.triggerID == triggerID2) {
                             expect(trigger.disabled).to.be.true;
@@ -146,14 +146,14 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                             expect(trigger.command.schemaVersion).to.equal(schemaVersion);
                             expect(trigger.command.actions).to.deep.equal(actions);
                             expect(trigger.command.targetID).to.deep.equal(targetID);
-                            expect(trigger.command.issuerID).to.deep.equal(issuerID);
+                            expect(trigger.command.issuerID.toString()).to.deep.equal(issuerID.toString());
                             expect(trigger.serverCode).to.be.null;
                         } else {
                             done("Unexpected TriggerID");
                         }
                     }
                     // 5. update trigger
-                    request = new thingIFSDK.CommandTriggerRequest("led2", 2, targetID, [{setBrightness: {brightness:50}}], statePredicate, issuerID);
+                    request = new thingIFSDK.CommandTriggerRequest("led2", 2, targetID, [{setBrightness: {brightness:50}}], statePredicate);
                     return api.patchCommandTrigger(triggerID1, request);
                 }).then((trigger:any)=>{
                     expect(trigger.triggerID).to.equal(triggerID1);
@@ -165,7 +165,7 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                     expect(trigger.command.schemaVersion).to.equal(2);
                     expect(trigger.command.actions).to.deep.equal([{setBrightness: {brightness:50}}]);
                     expect(trigger.command.targetID).to.deep.equal(targetID);
-                    expect(trigger.command.issuerID).to.deep.equal(issuerID);
+                    expect(trigger.command.issuerID.toString()).to.deep.equal(issuerID.toString());
                     expect(trigger.serverCode).to.be.null;
                     // 6. delete trigger
                     api._au._token = adminToken;
@@ -187,7 +187,7 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                     expect(queryResult.results[0].command.schemaVersion).to.equal(2);
                     expect(queryResult.results[0].command.actions).to.deep.equal([{setBrightness: {brightness:50}}]);
                     expect(queryResult.results[0].command.targetID).to.deep.equal(targetID);
-                    expect(queryResult.results[0].command.issuerID).to.deep.equal(issuerID);
+                    expect(queryResult.results[0].command.issuerID.toString()).to.deep.equal(issuerID.toString());
                     expect(queryResult.results[0].serverCode).to.be.null;
                     done();
                 }).catch((err:Error)=>{
@@ -221,7 +221,7 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                 var commandTarget = new TypedID(Types.Thing, commandTargetID);
                 var condition = new Condition(new Equals("power", "false"));
                 var statePredicate = new StatePredicate(condition, TriggersWhen.CONDITION_CHANGED);
-                var request = new CommandTriggerRequest(schema, schemaVersion, commandTarget, actions, statePredicate, issuerID);
+                var request = new CommandTriggerRequest(schema, schemaVersion, commandTarget, actions, statePredicate);
 
                 // 1. create command trigger with StatePredicate
                 api.postCommandTrigger(request).then((trigger:any)=>{
@@ -235,7 +235,7 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                     expect(trigger.command.schemaVersion).to.equal(schemaVersion);
                     expect(trigger.command.actions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(commandTarget);
-                    expect(trigger.command.issuerID).to.deep.equal(issuerID);
+                    expect(trigger.command.issuerID.toString()).to.deep.equal(issuerID.toString());
                     expect(trigger.serverCode).to.be.null;
                     return api.getTrigger(triggerID1);
                 }).then((trigger:any)=>{
@@ -248,7 +248,7 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                     expect(trigger.command.schemaVersion).to.equal(schemaVersion);
                     expect(trigger.command.actions).to.deep.equal(actions);
                     expect(JSON.stringify(trigger.command.targetID)).to.deep.equal(JSON.stringify(commandTarget));
-                    expect(JSON.stringify(trigger.command.issuerID)).to.deep.equal(JSON.stringify(issuerID));
+                    expect(JSON.stringify(trigger.command.issuerID.toString())).to.deep.equal(JSON.stringify(issuerID.toString()));
                     expect(trigger.serverCode).to.be.null;
                     done();
                 }).catch((err:Error)=>{
@@ -281,7 +281,7 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                 var commandTarget = new TypedID(Types.Thing, commandTargetID);
                 var condition = new Condition(new Equals("power", "false"));
                 var statePredicate = new StatePredicate(condition, TriggersWhen.CONDITION_CHANGED);
-                var request = new CommandTriggerRequest(schema, schemaVersion, targetID, actions, statePredicate, issuerID);
+                var request = new CommandTriggerRequest(schema, schemaVersion, targetID, actions, statePredicate);
 
                 // 1. create command trigger with StatePredicate
                 api.postCommandTrigger(request).then((trigger:any)=>{
@@ -295,7 +295,7 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                     expect(trigger.command.schemaVersion).to.equal(schemaVersion);
                     expect(trigger.command.actions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(targetID);
-                    expect(trigger.command.issuerID).to.deep.equal(issuerID);
+                    expect(trigger.command.issuerID.toString()).to.deep.equal(issuerID.toString());
                     expect(trigger.serverCode).to.be.null;
                     request = new thingIFSDK.CommandTriggerRequest("led2", 2, targetID, [{setBrightness: {brightness:50}}], statePredicate, issuerID, commandTarget);
                     return api.patchCommandTrigger(triggerID1, request);
@@ -309,7 +309,7 @@ describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
                     expect(trigger.command.schemaVersion).to.equal(2);
                     expect(trigger.command.actions).to.deep.equal([{setBrightness: {brightness:50}}]);
                     expect(JSON.stringify(trigger.command.targetID)).to.deep.equal(JSON.stringify(commandTarget));
-                    expect(JSON.stringify(trigger.command.issuerID)).to.deep.equal(JSON.stringify(issuerID));
+                    expect(JSON.stringify(trigger.command.issuerID.toString())).to.deep.equal(JSON.stringify(issuerID.toString()));
                     expect(trigger.serverCode).to.be.null;
                     done();
                 }).catch((err:Error)=>{

--- a/test/small/ThingIFAPITriggerTests/PatchTriggerTest.ts
+++ b/test/small/ThingIFAPITriggerTests/PatchTriggerTest.ts
@@ -33,9 +33,20 @@ let triggerID = "dummy-trigger-id";
 describe("Small Test ThingIFAPI#patchCommandTrigger", function() {
     let request = new CommandTriggerRequest(schema, schemaVersion, target, actions, predicate, owner);
     describe("handle IllegalStateError", function() {
-        let thingIFAPI = new ThingIFAPI(owner, ownerToken, testApp.app);
         it("when targe is null, IllegalStateError should be returned(promise)",
             function (done) {
+            let thingIFAPI = new ThingIFAPI(owner, ownerToken, testApp.app);
+            thingIFAPI.patchCommandTrigger(triggerID,request)
+            .then((trigger: Trigger)=>{
+                done("should fail");
+            }).catch((err)=>{
+                expect(err.name).to.equal(Errors.IlllegalStateError);
+                done();
+            })
+        })
+        it("when owner is null, IllegalStateError should be returned(promise)",
+            function (done) {
+            let thingIFAPI = new ThingIFAPI(null, ownerToken, testApp.app, target);
             thingIFAPI.patchCommandTrigger(triggerID,request)
             .then((trigger: Trigger)=>{
                 done("should fail");

--- a/test/small/ThingIFAPITriggerTests/PostTriggerTest.ts
+++ b/test/small/ThingIFAPITriggerTests/PostTriggerTest.ts
@@ -36,6 +36,18 @@ describe("Small Test ThingIFAPI#postCommandTrigger", function() {
         let thingIFAPI = new ThingIFAPI(owner, ownerToken, testApp.app);
         it("when targe is null, IllegalStateError should be returned(promise)",
             function (done) {
+            let thingIFAPI = new ThingIFAPI(owner, ownerToken, testApp.app);
+            thingIFAPI.postCommandTrigger(request)
+            .then((trigger: Trigger)=>{
+                done("should fail");
+            }).catch((err)=>{
+                expect(err.name).to.equal(Errors.IlllegalStateError);
+                done();
+            })
+        })
+        it("when owner is null, IllegalStateError should be returned(promise)",
+            function (done) {
+            let thingIFAPI = new ThingIFAPI(null, ownerToken, testApp.app, target);
             thingIFAPI.postCommandTrigger(request)
             .then((trigger: Trigger)=>{
                 done("should fail");

--- a/test/small/TriggerOpsTest.ts
+++ b/test/small/TriggerOpsTest.ts
@@ -345,12 +345,13 @@ describe('Test TriggerOps', function () {
             let predicate = new ScheduleOncePredicate(new Date().getTime());
             let tests = [
                 new TestCase(null, Errors.ArgumentError, "requestObject is null", "should handle error when requestObject is null"),
-                new TestCase(new CommandTriggerRequest(null, 1, target, [{turnPower: {power:true}}], predicate), Errors.ArgumentError, "schema is null or empty", "should handle error when schema is null"),
-                new TestCase(new CommandTriggerRequest("", 1, target, [{turnPower: {power:true}}], predicate), Errors.ArgumentError, "schema is null or empty", "should handle error when schema is empty"),
-                new TestCase(new CommandTriggerRequest("led", null, target, [{turnPower: {power:true}}], predicate), Errors.ArgumentError, "schemaVersion is null", "should handle error when schemaVersion is null"),
-                new TestCase(new CommandTriggerRequest("led", 1, target, null, predicate), Errors.ArgumentError, "actions is null", "should handle error when actions is null"),
-                new TestCase(new CommandTriggerRequest("led", 1, target, [{turnPower: {power:true}}], null), Errors.ArgumentError, "predicate is null", "should handle error when predicate is null"),
-                new TestCase(new CommandTriggerRequest("led", 1, null, [{turnPower: {power:true}}], predicate), Errors.ArgumentError, "commandTarget is null", "should handle error when commandTarget is null"),
+                new TestCase(new CommandTriggerRequest(null, 1, target, [{turnPower: {power:true}}], predicate, owner), Errors.ArgumentError, "schema is null or empty", "should handle error when schema is null"),
+                new TestCase(new CommandTriggerRequest("", 1, target, [{turnPower: {power:true}}], predicate, owner), Errors.ArgumentError, "schema is null or empty", "should handle error when schema is empty"),
+                new TestCase(new CommandTriggerRequest("led", null, target, [{turnPower: {power:true}}], predicate, owner), Errors.ArgumentError, "schemaVersion is null", "should handle error when schemaVersion is null"),
+                new TestCase(new CommandTriggerRequest("led", 1, target, null, predicate, owner), Errors.ArgumentError, "actions is null", "should handle error when actions is null"),
+                new TestCase(new CommandTriggerRequest("led", 1, target, [{turnPower: {power:true}}], null, owner), Errors.ArgumentError, "predicate is null", "should handle error when predicate is null"),
+                new TestCase(new CommandTriggerRequest("led", 1, null, [{turnPower: {power:true}}], predicate, owner), Errors.ArgumentError, "commandTarget is null", "should handle error when commandTarget is null"),
+                new TestCase(new CommandTriggerRequest("led", 1, target, [{turnPower: {power:true}}], predicate, null), Errors.ArgumentError, "issuerID is null", "should handle error when issuerID is null"),
             ]
             tests.forEach(function(test) {
                 it(test.description, function(done){


### PR DESCRIPTION
- `issuerID` of CommandTriggerRequest is required for APIAuthor#PostCommandTrigger/PatchCommandTrigger
- `issuerID` of CommandTriggerRequest is ignored in ThingIFAPI#PostCommandTrigger/PatchCommandTrigger, where ThingIFAPI#_owner is used instead. 
- validate `issuerID` in the above methods
- Improve API description