### PR TITLE
Post/Patch Trigger APIs

### DIFF
--- a/src/APIAuthor.ts
+++ b/src/APIAuthor.ts
@@ -188,7 +188,7 @@ export class APIAuthor {
 
     /** Post a new servercode trigger.
      * @param {TypedID} target TypedID of target, only Types.THING is supported now.
-     * @param {Object} requestObject Necessary fields for new servercode trigger.
+     * @param {PostServerCodeTriggerRequest} requestObject Necessary fields for new servercode trigger.
      * @param {onCompletion} [function] Callback function when completed
      * @return {Promise} promise object
      * @example
@@ -205,7 +205,7 @@ export class APIAuthor {
      */
     postServerCodeTrigger(
         target: TypedID,
-        requestObject: Options.ServerCodeTriggerRequest,
+        requestObject: Options.PostServerCodeTriggerRequest,
         onCompletion?: (err: Error, trigger:Trigger)=> void): Promise<Trigger>{
         return PromiseWrapper.promise((new TriggerOps(this,target)).postServerCodeTrigger(requestObject), onCompletion);
     }
@@ -264,7 +264,7 @@ export class APIAuthor {
     /** Update a servercode trigger.
      * @param {TypedID} target TypedID of target, only Types.THING is supported now.
      * @param {string} triggerID ID of trigger.
-     * @param {Object} requestObject The fields of trigger to be updated.
+     * @param {PatchServerCodeTriggerRequest} requestObject The fields of trigger to be updated.
      * @param {onCompletion} [function] Callback function when completed
      * @return {Promise} promise object
      * @example
@@ -282,7 +282,7 @@ export class APIAuthor {
    patchServerCodeTrigger(
         target: TypedID,
         triggerID: string,
-        requestObject: Options.ServerCodeTriggerRequest,
+        requestObject: Options.PatchServerCodeTriggerRequest,
         onCompletion?: (err: Error, trigger:Trigger)=> void): Promise<Trigger>{
         return PromiseWrapper.promise((new TriggerOps(this,target)).patchServerCodeTrigger(triggerID, requestObject), onCompletion);
     }

--- a/src/APIAuthor.ts
+++ b/src/APIAuthor.ts
@@ -181,7 +181,7 @@ export class APIAuthor {
      */
     postCommandTrigger(
         target: TypedID,
-        requestObject: Options.CommandTriggerRequest,
+        requestObject: Options.PostCommandTriggerRequest,
         onCompletion?: (err: Error, trigger:Trigger)=> void): Promise<Trigger>{
         return PromiseWrapper.promise((new TriggerOps(this,target)).postCommandTrigger(requestObject), onCompletion);
     }
@@ -256,7 +256,7 @@ export class APIAuthor {
     patchCommandTrigger(
         target: TypedID,
         triggerID: string,
-        requestObject: Options.CommandTriggerRequest,
+        requestObject: Options.PatchCommandTriggerRequest,
         onCompletion?: (err: Error, trigger:Trigger)=> void): Promise<Trigger>{
         return PromiseWrapper.promise((new TriggerOps(this,target)).patchCommandTrigger(triggerID, requestObject), onCompletion);
     }

--- a/src/APIAuthor.ts
+++ b/src/APIAuthor.ts
@@ -163,7 +163,7 @@ export class APIAuthor {
      *
      * @param {TypedID} target TypedID of target, only Types.THING is supported now.
      * @param {Object} requestObject Necessary fields for new command trigger.
-     *   IssuerID is required in requestObject.
+     *   IssuerID is required in requestObject. If requestObject.command.targetID is not provide or null, `target` parameter will be used.
      * @param {onCompletion} [function] Callback function when completed
      * @return {Promise} promise object
      * @example

--- a/src/RequestObjects.ts
+++ b/src/RequestObjects.ts
@@ -265,8 +265,8 @@ export class TriggerCommandObject {
      * @param {string} schema Name of schema.
      * @param {number} schemaVersion Version number of schema.
      * @param {number[]} actions Array of actions of the command.
+     * @param {TypedID} targetID instance of TypedID to represent target of command.
      * @param {TypedID} [issuerID] instance of TypedID to represent issuer of command.
-     * @param {TypedID} [targetID] instance of TypedID to represent target of command.
      * @param {string} [title] Title of the command.
      * @param {string} [description] Description of the command.
      * @param {Object} [metadata] Key-value list to store within command definition.
@@ -275,15 +275,16 @@ export class TriggerCommandObject {
         schema: string,
         schemaVersion: number,
         actions: Array<Object>,
+        targetID: TypedID,
         issuerID?: TypedID,
-        targetID?: TypedID,
         title?: string,
         description?: string,
         metadata?: Object) {
             this.schema = schema;
             this.schemaVersion = schemaVersion;
             this.actions = actions;
-            this
+            this.targetID = targetID;
+            this.issuerID = issuerID;
             this.title = title;
             this.description = description;
             this.metadata = metadata;

--- a/src/RequestObjects.ts
+++ b/src/RequestObjects.ts
@@ -308,9 +308,9 @@ export class PostCommandTriggerRequest{
      * @constructor
      * @param {PostCommandRequest} command the necessary fields to construct command.
      * @param {Predicate} predicate Predicate of the condition met for the trigger to execute.
-     * @prop [string] title Title of the trigger.
-     * @prop [string] description Description of the trigger.
-     * @prop [Object] metadata Key-value list to store within trigger definition.
+     * @param {string} [title] Title of the trigger.
+     * @param {string} [description] Description of the trigger.
+     * @param {Object} [metadata] Key-value list to store within trigger definition.
      */
     constructor(
         command: CommandTriggerCommandObject,
@@ -344,11 +344,11 @@ export class PatchCommandTriggerRequest{
     /**
      * Create a PostCommandTriggerRequest.
      * @constructor
-     * @param [CommandTriggerCommandObject] command the necessary fields to construct command.
-     * @param [Predicate] predicate Predicate of the condition met for the trigger to execute.
-     * @prop [string] title Title of the trigger.
-     * @prop [string] description Description of the trigger.
-     * @prop [Object] metadata Key-value list to store within trigger definition.
+     * @param {CommandTriggerCommandObject} [command] the necessary fields to construct command.
+     * @param {Predicate} [predicate] Predicate of the condition met for the trigger to execute.
+     * @param {string} [title] Title of the trigger.
+     * @param {string} [description] Description of the trigger.
+     * @param {Object} [metadata] Key-value list to store within trigger definition.
      */
     constructor(
         command?: CommandTriggerCommandObject,
@@ -366,11 +366,11 @@ export class PatchCommandTriggerRequest{
 }
 
 /**
- * Represents the request for creating/updating a server code trigger.
+ * Represents the request for creating a server code trigger.
  * @prop {ServerCode} serverCode Details of the server code to execute.
  * @prop {Predicate} predicate Predicate of the condition met for the trigger to execute.
  */
-export class ServerCodeTriggerRequest{
+export class PostServerCodeTriggerRequest{
     public serverCode: ServerCode;
     public predicate: Predicate;
 
@@ -383,6 +383,30 @@ export class ServerCodeTriggerRequest{
     constructor(
         serverCode: ServerCode,
         predicate: Predicate
+    ) {
+        this.serverCode = serverCode;
+        this.predicate = predicate;
+    }
+}
+
+/**
+ * Represents the request for updating a server code trigger.
+ * @prop {ServerCode} serverCode Details of the server code to execute.
+ * @prop {Predicate} predicate Predicate of the condition met for the trigger to execute.
+ */
+export class PatchServerCodeTriggerRequest{
+    public serverCode: ServerCode;
+    public predicate: Predicate;
+
+    /**
+     * Create a ServerCodeTriggerRequest.
+     * @constructor
+     * @param {ServerCode} [serverCode] Details of the server code to execute.
+     * @param {Predicate} [predicate] Predicate of the condition met for the trigger to execute.
+     */
+    constructor(
+        serverCode?: ServerCode,
+        predicate?: Predicate
     ) {
         this.serverCode = serverCode;
         this.predicate = predicate;

--- a/src/RequestObjects.ts
+++ b/src/RequestObjects.ts
@@ -249,7 +249,7 @@ export class ListQueryOptions {
  * @prop {string} description Description of the command.
  * @prop {Object} metadata Key-value list to store within command definition.
  */
-export class CommandTriggerCommandObject {
+export class TriggerCommandObject {
     public schema: string;
     public schemaVersion: number;
     public actions: Array<Object>;
@@ -291,14 +291,14 @@ export class CommandTriggerCommandObject {
 }
 /**
  * Represents the request for creating a command trigger.
- * @prop {CommandTriggerCommandObject} command instance of CommandTriggerCommandObject.
+ * @prop {TriggerCommandObject} command instance of TriggerCommandObject.
  * @prop {Predicate} predicate Predicate of the condition met for the trigger to execute.
  * @prop {string} title Title of the trigger.
  * @prop {string} description Description of the trigger.
  * @prop {Object} metadata Key-value list to store within trigger definition.
  */
 export class PostCommandTriggerRequest{
-    public command: CommandTriggerCommandObject;
+    public command: TriggerCommandObject;
     public predicate: Predicate;
     public title: string;
     public description: string;
@@ -313,7 +313,7 @@ export class PostCommandTriggerRequest{
      * @param {Object} [metadata] Key-value list to store within trigger definition.
      */
     constructor(
-        command: CommandTriggerCommandObject,
+        command: TriggerCommandObject,
         predicate: Predicate,
         title?: string,
         description?: string,
@@ -329,14 +329,14 @@ export class PostCommandTriggerRequest{
 
 /**
  * Represents the request for updating a command trigger.
- * @prop {CommandTriggerCommandObject} command instance of CommandTriggerCommandObject.
+ * @prop {TriggerCommandObject} command instance of TriggerCommandObject.
  * @prop {Predicate} predicate Predicate of the condition met for the trigger to execute.
  * @prop {string} title Title of the trigger.
  * @prop {string} description Description of the trigger.
  * @prop {Object} metadata Key-value list to store within trigger definition.
  */
 export class PatchCommandTriggerRequest{
-    public command: CommandTriggerCommandObject;
+    public command: TriggerCommandObject;
     public predicate: Predicate;
     public title: string;
     public description: string;
@@ -344,14 +344,14 @@ export class PatchCommandTriggerRequest{
     /**
      * Create a PostCommandTriggerRequest.
      * @constructor
-     * @param {CommandTriggerCommandObject} [command] the necessary fields to construct command.
+     * @param {TriggerCommandObject} [command] the necessary fields to construct command.
      * @param {Predicate} [predicate] Predicate of the condition met for the trigger to execute.
      * @param {string} [title] Title of the trigger.
      * @param {string} [description] Description of the trigger.
      * @param {Object} [metadata] Key-value list to store within trigger definition.
      */
     constructor(
-        command?: CommandTriggerCommandObject,
+        command?: TriggerCommandObject,
         predicate?: Predicate,
         title?: string,
         description?: string,

--- a/src/RequestObjects.ts
+++ b/src/RequestObjects.ts
@@ -239,45 +239,129 @@ export class ListQueryOptions {
 }
 
 /**
- * Represents the request for creating/updating a command trigger.
+ * Represents the fields to construct command for creating/updating command trigger.
  * @prop {string} schema Name of schema.
  * @prop {number} schemaVersion Version number of schema.
  * @prop {Object[]} actions Array of actions of the command.
- * @prop {Predicate} predicate Predicate of the condition met for the trigger to execute.
- * @prop {TypedID} issuerID ID of the command issuer.
+ * @prop {TypedID} issuerID instance of TypedID to represent issuer of command.
+ * @prop {TypedID} targetID instance of TypedID to represent target of command.
+ * @prop {string} title Title of the command.
+ * @prop {string} description Description of the command.
+ * @prop {Object} metadata Key-value list to store within command definition.
  */
-export class CommandTriggerRequest{
+export class CommandTriggerCommandObject {
     public schema: string;
     public schemaVersion: number;
     public actions: Array<Object>;
-    public predicate: Predicate;
     public issuerID: TypedID;
-    public commandTarget: TypedID;
+    public targetID: TypedID;
+    public title: string;
+    public description: string;
+    public metadata: Object;
 
     /**
-     * Create a CommandTriggerRequest.
+     * Create a PostCommandRequest.
      * @constructor
      * @param {string} schema Name of schema.
      * @param {number} schemaVersion Version number of schema.
-     * @param {TypedID} commandTarget target of command to be sent, when condition of predication meets.
-     * @param {Object[]} actions Array of actions of the command.
-     * @param {Predicate} predicate Predicate of the condition met for the trigger to execute.
-     * @param {TypedID} issuerID ID of the command issuer.
+     * @param {number[]} actions Array of actions of the command.
+     * @param {TypedID} [issuerID] instance of TypedID to represent issuer of command.
+     * @param {TypedID} [targetID] instance of TypedID to represent target of command.
+     * @param {string} [title] Title of the command.
+     * @param {string} [description] Description of the command.
+     * @param {Object} [metadata] Key-value list to store within command definition.
      */
     constructor(
         schema: string,
         schemaVersion: number,
-        commandTarget: TypedID,
-        actions?: Array<Object>,
-        predicate?: Predicate,
-        issuerID?: TypedID
+        actions: Array<Object>,
+        issuerID?: TypedID,
+        targetID?: TypedID,
+        title?: string,
+        description?: string,
+        metadata?: Object) {
+            this.schema = schema;
+            this.schemaVersion = schemaVersion;
+            this.actions = actions;
+            this
+            this.title = title;
+            this.description = description;
+            this.metadata = metadata;
+        }
+}
+/**
+ * Represents the request for creating a command trigger.
+ * @prop {CommandTriggerCommandObject} command instance of CommandTriggerCommandObject.
+ * @prop {Predicate} predicate Predicate of the condition met for the trigger to execute.
+ * @prop {string} title Title of the trigger.
+ * @prop {string} description Description of the trigger.
+ * @prop {Object} metadata Key-value list to store within trigger definition.
+ */
+export class PostCommandTriggerRequest{
+    public command: CommandTriggerCommandObject;
+    public predicate: Predicate;
+    public title: string;
+    public description: string;
+    public metadata: Object;
+    /**
+     * Create a PostCommandTriggerRequest.
+     * @constructor
+     * @param {PostCommandRequest} command the necessary fields to construct command.
+     * @param {Predicate} predicate Predicate of the condition met for the trigger to execute.
+     * @prop [string] title Title of the trigger.
+     * @prop [string] description Description of the trigger.
+     * @prop [Object] metadata Key-value list to store within trigger definition.
+     */
+    constructor(
+        command: CommandTriggerCommandObject,
+        predicate: Predicate,
+        title?: string,
+        description?: string,
+        metadata?: Object
     ) {
-        this.schema = schema;
-        this.schemaVersion = schemaVersion;
-        this.actions = actions;
+        this.command = command;
         this.predicate = predicate;
-        this.issuerID = issuerID;
-        this.commandTarget = commandTarget
+        this.title = title;
+        this.description = description;
+        this.metadata = metadata;
+    }
+}
+
+/**
+ * Represents the request for updating a command trigger.
+ * @prop {CommandTriggerCommandObject} command instance of CommandTriggerCommandObject.
+ * @prop {Predicate} predicate Predicate of the condition met for the trigger to execute.
+ * @prop {string} title Title of the trigger.
+ * @prop {string} description Description of the trigger.
+ * @prop {Object} metadata Key-value list to store within trigger definition.
+ */
+export class PatchCommandTriggerRequest{
+    public command: CommandTriggerCommandObject;
+    public predicate: Predicate;
+    public title: string;
+    public description: string;
+    public metadata: Object;
+    /**
+     * Create a PostCommandTriggerRequest.
+     * @constructor
+     * @param [CommandTriggerCommandObject] command the necessary fields to construct command.
+     * @param [Predicate] predicate Predicate of the condition met for the trigger to execute.
+     * @prop [string] title Title of the trigger.
+     * @prop [string] description Description of the trigger.
+     * @prop [Object] metadata Key-value list to store within trigger definition.
+     */
+    constructor(
+        command?: CommandTriggerCommandObject,
+        predicate?: Predicate,
+        title?: string,
+        description?: string,
+        metadata?: Object
+    ) {
+        this.command = command;
+        this.predicate = predicate;
+        this.title = title;
+        this.description = description;
+        this.metadata = metadata;
     }
 }
 

--- a/src/RequestObjects.ts
+++ b/src/RequestObjects.ts
@@ -398,6 +398,9 @@ export class PostServerCodeTriggerRequest{
     ) {
         this.serverCode = serverCode;
         this.predicate = predicate;
+        this.title = title;
+        this.description = description;
+        this.metadata = metadata;
     }
 }
 
@@ -433,5 +436,8 @@ export class PatchServerCodeTriggerRequest{
     ) {
         this.serverCode = serverCode;
         this.predicate = predicate;
+        this.title = title;
+        this.description = description;
+        this.metadata = metadata;
     }
 }

--- a/src/RequestObjects.ts
+++ b/src/RequestObjects.ts
@@ -370,20 +370,31 @@ export class PatchCommandTriggerRequest{
  * Represents the request for creating a server code trigger.
  * @prop {ServerCode} serverCode Details of the server code to execute.
  * @prop {Predicate} predicate Predicate of the condition met for the trigger to execute.
+ * @prop {string} title Title of the trigger.
+ * @prop {string} description Description of the trigger.
+ * @prop {Object} metadata Key-value list to store within trigger definition.
  */
 export class PostServerCodeTriggerRequest{
     public serverCode: ServerCode;
     public predicate: Predicate;
-
+    public title: string;
+    public description: string;
+    public metadata: Object;
     /**
      * Create a ServerCodeTriggerRequest.
      * @constructor
      * @param {ServerCode} serverCode Details of the server code to execute.
      * @param {Predicate} predicate Predicate of the condition met for the trigger to execute.
+     * @param {string} [title] Title of the trigger.
+     * @param {string} [description] Description of the trigger.
+     * @param {Object} [metadata] Key-value list to store within trigger definition.
      */
     constructor(
         serverCode: ServerCode,
-        predicate: Predicate
+        predicate: Predicate,
+        title?: string,
+        description?: string,
+        metadata?: Object
     ) {
         this.serverCode = serverCode;
         this.predicate = predicate;
@@ -394,20 +405,31 @@ export class PostServerCodeTriggerRequest{
  * Represents the request for updating a server code trigger.
  * @prop {ServerCode} serverCode Details of the server code to execute.
  * @prop {Predicate} predicate Predicate of the condition met for the trigger to execute.
+ * @prop {string} title Title of the trigger.
+ * @prop {string} description Description of the trigger.
+ * @prop {Object} metadata Key-value list to store within trigger definition.
  */
 export class PatchServerCodeTriggerRequest{
     public serverCode: ServerCode;
     public predicate: Predicate;
-
+    public title: string;
+    public description: string;
+    public metadata: Object;
     /**
      * Create a ServerCodeTriggerRequest.
      * @constructor
      * @param {ServerCode} [serverCode] Details of the server code to execute.
      * @param {Predicate} [predicate] Predicate of the condition met for the trigger to execute.
+     * @param {string} [title] Title of the trigger.
+     * @param {string} [description] Description of the trigger.
+     * @param {Object} [metadata] Key-value list to store within trigger definition.
      */
     constructor(
         serverCode?: ServerCode,
-        predicate?: Predicate
+        predicate?: Predicate,
+        title?: string,
+        description?: string,
+        metadata?: Object
     ) {
         this.serverCode = serverCode;
         this.predicate = predicate;

--- a/src/ThingIFAPI.ts
+++ b/src/ThingIFAPI.ts
@@ -265,7 +265,7 @@ export class ThingIFAPI {
      * });
      */
     postCommandTrigger(
-        requestObject: Options.CommandTriggerRequest,
+        requestObject: Options.PostCommandTriggerRequest,
         onCompletion?: (err: Error, trigger:Trigger)=> void): Promise<Trigger>{
         let orgPromise = new Promise<Trigger>((resolve, reject)=>{
             if(!this._target){
@@ -377,7 +377,7 @@ export class ThingIFAPI {
      */
     patchCommandTrigger(
         triggerID: string,
-        requestObject: Options.CommandTriggerRequest,
+        requestObject: Options.PatchCommandTriggerRequest,
         onCompletion?: (err: Error, trigger:Trigger)=> void): Promise<Trigger>{
         let orgPromise = new Promise<Trigger>((resolve, reject)=>{
             if(!this._target){

--- a/src/ThingIFAPI.ts
+++ b/src/ThingIFAPI.ts
@@ -251,6 +251,7 @@ export class ThingIFAPI {
      *
      * @param {Object} requestObject Necessary fields for new command trigger.
      *   `_owner` property is used as IssuerID. So even if IssuerID is provided in requestObject, it will be ignored.
+     *   If requestObject.command.targetID is not provide or null, `_target` property will be used by default.
      * @param {onCompletion} [function] Callback function when completed
      * @return {Promise} promise object
      * @example

--- a/src/ThingIFAPI.ts
+++ b/src/ThingIFAPI.ts
@@ -286,7 +286,7 @@ export class ThingIFAPI {
      *
      * **Note**: Please onboard first, or provide a target when constructor ThingIFAPI.
      *  Otherwise, error will be returned.
-     * @param {Object} requestObject Necessary fields for new servercode trigger.
+     * @param {PostServerCodeTriggerRequest} requestObject Necessary fields for new servercode trigger.
      * @param {onCompletion} [function] Callback function when completed
      * @return {Promise} promise object
      * @example
@@ -301,7 +301,7 @@ export class ThingIFAPI {
      * });
      */
     postServerCodeTrigger(
-        requestObject: Options.ServerCodeTriggerRequest,
+        requestObject: Options.PostServerCodeTriggerRequest,
         onCompletion?: (err: Error, trigger:Trigger)=> void): Promise<Trigger>{
         let orgPromise = new Promise<Trigger>((resolve, reject)=>{
             if(!this._target){
@@ -415,7 +415,7 @@ export class ThingIFAPI {
      */
    patchServerCodeTrigger(
         triggerID: string,
-        requestObject: Options.ServerCodeTriggerRequest,
+        requestObject: Options.PatchServerCodeTriggerRequest,
         onCompletion?: (err: Error, trigger:Trigger)=> void): Promise<Trigger>{
         let orgPromise = new Promise<Trigger>((resolve, reject)=>{
             if(!this._target){
@@ -502,6 +502,7 @@ export class ThingIFAPI {
      *
      * **Note**: Please onboard first, or provide a target when constructor ThingIFAPI.
      *  Otherwise, error will be returned.
+     * @param {ListQueryOptions} listOptions instance to ListQueryOptions.
      * @param {onCompletion} [function] Callback function when completed
      * @return {Promise} promise object
      * @example

--- a/src/ops/TriggerOps.ts
+++ b/src/ops/TriggerOps.ts
@@ -305,7 +305,7 @@ export default class TriggerOps extends BaseOp {
             if(!!requestObject.metadata){
                 requestBody["metadata"] = requestObject.metadata;
             }
-            this.patchTriggger(triggerID, requestObject).then((result)=>{
+            this.patchTriggger(triggerID, requestBody).then((result)=>{
                 resolve(result);
             }).catch((err)=>{
                 reject(err);

--- a/src/ops/TriggerOps.ts
+++ b/src/ops/TriggerOps.ts
@@ -67,6 +67,7 @@ export default class TriggerOps extends BaseOp {
                 reject(new ThingIFError(Errors.ArgumentError, "issuerID of command is null"));
                 return;
             }
+
             var command = new Command(
                 commandRequest.targetID,
                 commandRequest.issuerID,
@@ -77,15 +78,31 @@ export default class TriggerOps extends BaseOp {
             command.description = commandRequest.description;
             command.metadata = commandRequest.metadata;
 
-            var resuestBody = {
+            var requestBody: any = {
                 predicate: requestObject.predicate.toJson(),
                 triggersWhat: TriggersWhat.COMMAND,
                 command: command.toJson()
             }
-            this.postTrigger(resuestBody).then((res:Response)=>{
+
+            if(!!requestObject.title){
+                requestBody["title"]= requestObject.title;
+            }
+
+            if(!!requestObject.description){
+                requestBody["description"] = requestObject.description;
+            }
+
+            if(!!requestObject.metadata){
+                requestBody["metadata"] = requestObject.metadata;
+            }
+
+            this.postTrigger(requestBody).then((res:Response)=>{
                 var trigger = new Trigger(requestObject.predicate, command, null);
                 trigger.triggerID = (<any>res).body.triggerID;
                 trigger.disabled = false;
+                trigger.title = requestObject.title;
+                trigger.description = requestObject.description;
+                trigger.metadata = requestObject.metadata;
                 resolve(trigger);
             }).catch((err)=>{
                 reject(err);
@@ -106,15 +123,29 @@ export default class TriggerOps extends BaseOp {
                 reject(new ThingIFError(Errors.ArgumentError, "predicate is null"));
                 return;
             }
-            var resuestBody = {
+            var requestBody:any = {
                 predicate: requestObject.predicate.toJson(),
                 triggersWhat: TriggersWhat.SERVER_CODE,
                 serverCode: requestObject.serverCode.toJson()
             }
-            this.postTrigger(resuestBody).then((res:Response)=>{
+            if(!!requestObject.title){
+                requestBody["title"]= requestObject.title;
+            }
+
+            if(!!requestObject.description){
+                requestBody["description"] = requestObject.description;
+            }
+
+            if(!!requestObject.metadata){
+                requestBody["metadata"] = requestObject.metadata;
+            }
+            this.postTrigger(requestObject).then((res:Response)=>{
                 var trigger:Trigger = new Trigger(requestObject.predicate, null, requestObject.serverCode);
                 trigger.triggerID = (<any>res).body.triggerID;
                 trigger.disabled = false;
+                trigger.title = requestObject.title;
+                trigger.description = requestObject.description;
+                trigger.metadata = requestObject.metadata;
                 resolve(trigger);
             }).catch((err)=>{
                 reject(err);
@@ -220,6 +251,17 @@ export default class TriggerOps extends BaseOp {
                 requestBody["command"] = command.toJson();
                 requestBody["triggersWhat"] = "COMMAND";
             }
+            if(!!requestObject.title){
+                requestBody["title"]= requestObject.title;
+            }
+
+            if(!!requestObject.description){
+                requestBody["description"] = requestObject.description;
+            }
+
+            if(!!requestObject.metadata){
+                requestBody["metadata"] = requestObject.metadata;
+            }
             this.patchTriggger(triggerID, requestBody).then((result)=>{
                 resolve(result);
             }).catch((err)=>{
@@ -247,12 +289,23 @@ export default class TriggerOps extends BaseOp {
                 reject(new ThingIFError(Errors.ArgumentError, "must specify serverCode or predicate"));
                 return;
             }
-            var resuestBody = {
+            var requestBody: any = {
                 predicate: requestObject.predicate.toJson(),
                 triggersWhat: TriggersWhat.SERVER_CODE,
                 serverCode: requestObject.serverCode.toJson()
             }
-            this.patchTriggger(triggerID, resuestBody).then((result)=>{
+            if(!!requestObject.title){
+                requestBody["title"]= requestObject.title;
+            }
+
+            if(!!requestObject.description){
+                requestBody["description"] = requestObject.description;
+            }
+
+            if(!!requestObject.metadata){
+                requestBody["metadata"] = requestObject.metadata;
+            }
+            this.patchTriggger(triggerID, requestObject).then((result)=>{
                 resolve(result);
             }).catch((err)=>{
                 reject(err);

--- a/src/ops/TriggerOps.ts
+++ b/src/ops/TriggerOps.ts
@@ -63,13 +63,8 @@ export default class TriggerOps extends BaseOp {
                 return;
             }
 
-            if (!commandRequest.targetID) {
-                reject(new ThingIFError(Errors.ArgumentError, "commandTarget is null"));
-                return;
-            }
-
             if (!commandRequest.issuerID) {
-                reject(new ThingIFError(Errors.ArgumentError, "issuerID is null"));
+                reject(new ThingIFError(Errors.ArgumentError, "issuerID of command is null"));
                 return;
             }
             var command = new Command(
@@ -183,10 +178,9 @@ export default class TriggerOps extends BaseOp {
                 reject(new ThingIFError(Errors.ArgumentError, "requestObject is null"));
                 return;
             }
-            let resuestBody:any = {}
-
+            let requestBody:any = {}
             if(!!requestObject.predicate){
-                requestObject["predicate"] = requestObject.predicate.toJson();
+                requestBody["predicate"] = requestObject.predicate.toJson();
             }
 
             if(!!requestObject.command){
@@ -223,11 +217,10 @@ export default class TriggerOps extends BaseOp {
                 command.title = commandRequest.title;
                 command.description = commandRequest.description;
                 command.metadata = commandRequest.metadata;
-                resuestBody["command"] = command.toJson();
-                resuestBody["triggersWhat"] = "COMMAND";
+                requestBody["command"] = command.toJson();
+                requestBody["triggersWhat"] = "COMMAND";
             }
-
-            this.patchTriggger(triggerID, resuestBody).then((result)=>{
+            this.patchTriggger(triggerID, requestBody).then((result)=>{
                 resolve(result);
             }).catch((err)=>{
                 reject(err);

--- a/src/ops/TriggerOps.ts
+++ b/src/ops/TriggerOps.ts
@@ -34,7 +34,7 @@ export default class TriggerOps extends BaseOp {
                 reject(new ThingIFError(Errors.ArgumentError, "requestObject is null"));
                 return;
             }
-            if(!!requestObject.command){
+            if(!requestObject.command){
                 reject(new ThingIFError(Errors.ArgumentError, "command is null"));
                 return;
             }

--- a/src/ops/TriggerOps.ts
+++ b/src/ops/TriggerOps.ts
@@ -139,7 +139,7 @@ export default class TriggerOps extends BaseOp {
             if(!!requestObject.metadata){
                 requestBody["metadata"] = requestObject.metadata;
             }
-            this.postTrigger(requestObject).then((res:Response)=>{
+            this.postTrigger(requestBody).then((res:Response)=>{
                 var trigger:Trigger = new Trigger(requestObject.predicate, null, requestObject.serverCode);
                 trigger.triggerID = (<any>res).body.triggerID;
                 trigger.disabled = false;

--- a/src/ops/TriggerOps.ts
+++ b/src/ops/TriggerOps.ts
@@ -68,8 +68,13 @@ export default class TriggerOps extends BaseOp {
                 return;
             }
 
+            var commandTarget = this.target;
+            if(!!commandRequest.targetID){
+                commandTarget = commandRequest.targetID;
+            }
+
             var command = new Command(
-                commandRequest.targetID,
+                commandTarget,
                 commandRequest.issuerID,
                 commandRequest.schema,
                 commandRequest.schemaVersion,
@@ -229,10 +234,6 @@ export default class TriggerOps extends BaseOp {
                 }
                 if (!commandRequest.actions) {
                     reject(new ThingIFError(Errors.ArgumentError, "actions of command is null"));
-                    return;
-                }
-                if (!commandRequest.targetID) {
-                    reject(new ThingIFError(Errors.ArgumentError, "targetID of command is null"));
                     return;
                 }
                 if (!commandRequest.issuerID) {

--- a/src/ops/TriggerOps.ts
+++ b/src/ops/TriggerOps.ts
@@ -7,7 +7,13 @@ import {APIAuthor} from '../APIAuthor';
 import BaseOp from './BaseOp'
 import {Trigger, TriggersWhat} from '../Trigger'
 import {QueryResult} from '../QueryResult'
-import {PostCommandTriggerRequest, ServerCodeTriggerRequest, ListQueryOptions, PatchCommandTriggerRequest} from '../RequestObjects'
+import {
+        PostCommandTriggerRequest,
+        PostServerCodeTriggerRequest,
+        ListQueryOptions,
+        PatchCommandTriggerRequest,
+        PatchServerCodeTriggerRequest
+    } from '../RequestObjects'
 import {ThingIFError, HttpRequestError, Errors} from '../ThingIFError'
 import {TypedID} from '../TypedID'
 import {Command} from '../Command'
@@ -82,7 +88,7 @@ export default class TriggerOps extends BaseOp {
             });
         });
     }
-    postServerCodeTrigger(requestObject: ServerCodeTriggerRequest): Promise<Trigger> {
+    postServerCodeTrigger(requestObject: PostServerCodeTriggerRequest): Promise<Trigger> {
         return new Promise<Trigger>((resolve, reject)=>{
             if (!requestObject) {
                 reject(new ThingIFError(Errors.ArgumentError, "requestObject is null"));
@@ -218,7 +224,7 @@ export default class TriggerOps extends BaseOp {
 
     patchServerCodeTrigger(
         triggerID: string,
-        requestObject: ServerCodeTriggerRequest): Promise<Trigger> {
+        requestObject: PatchServerCodeTriggerRequest): Promise<Trigger> {
         return new Promise<Trigger>((resolve, reject)=>{
             if (!triggerID) {
                 reject(new ThingIFError(Errors.ArgumentError, "triggerID is null or empty"));

--- a/test/large/ThingIFAPITriggerTest.ts
+++ b/test/large/ThingIFAPITriggerTest.ts
@@ -23,7 +23,7 @@ import {
 declare var require: any
 let thingIFSDK = require('../../../dist/thing-if-sdk.js');
 
-describe.only("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
+describe("Large Tests for APIAuthor Trigger APIs(ThingIFAPI):", function () {
 
     let user: KiiUser;
     let api: any;

--- a/test/small/APIAuthorTriggerTests/EnableTriggerTest.ts
+++ b/test/small/APIAuthorTriggerTests/EnableTriggerTest.ts
@@ -8,7 +8,6 @@ import TestApp from '../TestApp'
 import {APIAuthor} from '../../../src/APIAuthor';
 import {TypedID} from '../../../src/TypedID';
 import {Types} from '../../../src/TypedID';
-import {CommandTriggerRequest, ServerCodeTriggerRequest, ListQueryOptions} from '../../../src/RequestObjects';
 import TriggerOps from '../../../src/ops/TriggerOps'
 import {Trigger, TriggersWhen, TriggersWhat} from '../../../src/Trigger';
 import {Command, CommandState} from '../../../src/Command';

--- a/test/small/APIAuthorTriggerTests/GetTriggerTest.ts
+++ b/test/small/APIAuthorTriggerTests/GetTriggerTest.ts
@@ -8,7 +8,6 @@ import TestApp from '../TestApp'
 import {APIAuthor} from '../../../src/APIAuthor';
 import {TypedID} from '../../../src/TypedID';
 import {Types} from '../../../src/TypedID';
-import {CommandTriggerRequest, ServerCodeTriggerRequest, ListQueryOptions} from '../../../src/RequestObjects';
 import TriggerOps from '../../../src/ops/TriggerOps'
 import {Trigger, TriggersWhen, TriggersWhat} from '../../../src/Trigger';
 import {Command, CommandState} from '../../../src/Command';

--- a/test/small/APIAuthorTriggerTests/ListTriggersTest.ts
+++ b/test/small/APIAuthorTriggerTests/ListTriggersTest.ts
@@ -8,7 +8,6 @@ import TestApp from '../TestApp'
 import {APIAuthor} from '../../../src/APIAuthor';
 import {TypedID} from '../../../src/TypedID';
 import {Types} from '../../../src/TypedID';
-import {CommandTriggerRequest, ServerCodeTriggerRequest, ListQueryOptions} from '../../../src/RequestObjects';
 import TriggerOps from '../../../src/ops/TriggerOps'
 import {Trigger, TriggersWhen, TriggersWhat} from '../../../src/Trigger';
 import {Command, CommandState} from '../../../src/Command';

--- a/test/small/APIAuthorTriggerTests/PatchTriggerTest.ts
+++ b/test/small/APIAuthorTriggerTests/PatchTriggerTest.ts
@@ -8,7 +8,7 @@ import TestApp from '../TestApp'
 import {APIAuthor} from '../../../src/APIAuthor';
 import {TypedID} from '../../../src/TypedID';
 import {Types} from '../../../src/TypedID';
-import {CommandTriggerRequest, ServerCodeTriggerRequest, ListQueryOptions} from '../../../src/RequestObjects';
+import {PatchCommandTriggerRequest, PatchServerCodeTriggerRequest, ListQueryOptions, TriggerCommandObject} from '../../../src/RequestObjects';
 import TriggerOps from '../../../src/ops/TriggerOps'
 import {Trigger, TriggersWhen, TriggersWhat} from '../../../src/Trigger';
 import {Command, CommandState} from '../../../src/Command';
@@ -31,7 +31,7 @@ let predicate = new StatePredicate(condition, TriggersWhen.CONDITION_CHANGED);
 let serverCode = new ServerCode("server_function", ownerToken, testApp.appID, {brightness : 100, color : "#FFF"});
 let triggerID = "dummy-trigger-id";
 describe("Small Test APIAuthor#patchCommandTrigger", function() {
-    let request = new CommandTriggerRequest(schemaName, schemaVersion, target, actions, predicate, owner);
+    let request = new PatchCommandTriggerRequest(new TriggerCommandObject(schemaName, schemaVersion, actions, target, owner), predicate);
 
     describe("handle http response", function() {
         let au = new APIAuthor(ownerToken, testApp.app);
@@ -122,7 +122,7 @@ describe("Small Test APIAuthor#patchCommandTrigger", function() {
 })
 
 describe("Small Test APIAuthor#patchServerCodeTrigger", function() {
-    let request = new ServerCodeTriggerRequest(serverCode, predicate);
+    let request = new PatchServerCodeTriggerRequest(serverCode, predicate);
 
     describe("handle http response", function() {
         let au = new APIAuthor(ownerToken, testApp.app);

--- a/test/small/APIAuthorTriggerTests/PostTriggerTest.ts
+++ b/test/small/APIAuthorTriggerTests/PostTriggerTest.ts
@@ -8,7 +8,7 @@ import TestApp from '../TestApp'
 import {APIAuthor} from '../../../src/APIAuthor';
 import {TypedID} from '../../../src/TypedID';
 import {Types} from '../../../src/TypedID';
-import {CommandTriggerRequest, ServerCodeTriggerRequest, ListQueryOptions} from '../../../src/RequestObjects';
+import {PostCommandTriggerRequest, PostServerCodeTriggerRequest, ListQueryOptions, TriggerCommandObject} from '../../../src/RequestObjects';
 import TriggerOps from '../../../src/ops/TriggerOps'
 import {Trigger, TriggersWhen, TriggersWhat} from '../../../src/Trigger';
 import {Command, CommandState} from '../../../src/Command';
@@ -31,7 +31,7 @@ let predicate = new StatePredicate(condition, TriggersWhen.CONDITION_CHANGED);
 let serverCode = new ServerCode("server_function", ownerToken, testApp.appID, {brightness : 100, color : "#FFF"});
 
 describe("Small Test APIAuthor#postCommandTrigger", function() {
-    let request = new CommandTriggerRequest(schemaName, schemaVersion, target, actions, predicate, owner);
+    let request = new PostCommandTriggerRequest(new TriggerCommandObject(schemaName, schemaVersion, actions, target, owner), predicate);
 
     describe("handle http response", function() {
         let au = new APIAuthor(ownerToken, testApp.app);
@@ -122,7 +122,7 @@ describe("Small Test APIAuthor#postCommandTrigger", function() {
 })
 
 describe("Small Test APIAuthor#postServerCodeTrigger", function() {
-    let request = new ServerCodeTriggerRequest(serverCode, predicate);
+    let request = new PostServerCodeTriggerRequest(serverCode, predicate);
     describe("handle http response", function() {
         let au = new APIAuthor(ownerToken, testApp.app);
 

--- a/test/small/ThingIFAPITriggerTests/EnableTriggerTest.ts
+++ b/test/small/ThingIFAPITriggerTests/EnableTriggerTest.ts
@@ -8,7 +8,6 @@ import TestApp from '../TestApp'
 import {ThingIFAPI} from '../../../src/ThingIFAPI';
 import {TypedID} from '../../../src/TypedID';
 import {Types} from '../../../src/TypedID';
-import {CommandTriggerRequest, ServerCodeTriggerRequest, ListQueryOptions} from '../../../src/RequestObjects';
 import TriggerOps from '../../../src/ops/TriggerOps'
 import {Trigger, TriggersWhen, TriggersWhat} from '../../../src/Trigger';
 import {Command, CommandState} from '../../../src/Command';

--- a/test/small/ThingIFAPITriggerTests/GetTriggerTest.ts
+++ b/test/small/ThingIFAPITriggerTests/GetTriggerTest.ts
@@ -8,7 +8,6 @@ import TestApp from '../TestApp'
 import {ThingIFAPI} from '../../../src/ThingIFAPI';
 import {TypedID} from '../../../src/TypedID';
 import {Types} from '../../../src/TypedID';
-import {CommandTriggerRequest, ServerCodeTriggerRequest, ListQueryOptions} from '../../../src/RequestObjects';
 import TriggerOps from '../../../src/ops/TriggerOps'
 import {Trigger, TriggersWhen, TriggersWhat} from '../../../src/Trigger';
 import {Command, CommandState} from '../../../src/Command';

--- a/test/small/ThingIFAPITriggerTests/ListTriggersTest.ts
+++ b/test/small/ThingIFAPITriggerTests/ListTriggersTest.ts
@@ -8,7 +8,6 @@ import TestApp from '../TestApp'
 import {ThingIFAPI} from '../../../src/ThingIFAPI';
 import {TypedID} from '../../../src/TypedID';
 import {Types} from '../../../src/TypedID';
-import {CommandTriggerRequest, ServerCodeTriggerRequest, ListQueryOptions} from '../../../src/RequestObjects';
 import TriggerOps from '../../../src/ops/TriggerOps'
 import {Trigger, TriggersWhen, TriggersWhat} from '../../../src/Trigger';
 import {Command, CommandState} from '../../../src/Command';

--- a/test/small/ThingIFAPITriggerTests/PatchTriggerTest.ts
+++ b/test/small/ThingIFAPITriggerTests/PatchTriggerTest.ts
@@ -8,7 +8,7 @@ import TestApp from '../TestApp'
 import {ThingIFAPI} from '../../../src/ThingIFAPI';
 import {TypedID} from '../../../src/TypedID';
 import {Types} from '../../../src/TypedID';
-import {CommandTriggerRequest, ServerCodeTriggerRequest, ListQueryOptions} from '../../../src/RequestObjects';
+import {PatchCommandTriggerRequest, PatchServerCodeTriggerRequest, ListQueryOptions, TriggerCommandObject} from '../../../src/RequestObjects';
 import TriggerOps from '../../../src/ops/TriggerOps'
 import {Trigger, TriggersWhen, TriggersWhat} from '../../../src/Trigger';
 import {Command, CommandState} from '../../../src/Command';
@@ -31,7 +31,7 @@ let predicate = new StatePredicate(condition, TriggersWhen.CONDITION_CHANGED);
 let serverCode = new ServerCode("server_function", ownerToken, testApp.appID, {brightness : 100, color : "#FFF"});
 let triggerID = "dummy-trigger-id";
 describe("Small Test ThingIFAPI#patchCommandTrigger", function() {
-    let request = new CommandTriggerRequest(schema, schemaVersion, target, actions, predicate, owner);
+    let request = new PatchCommandTriggerRequest(new TriggerCommandObject(schema, schemaVersion, actions, target, owner), predicate);
     describe("handle IllegalStateError", function() {
         it("when targe is null, IllegalStateError should be returned(promise)",
             function (done) {
@@ -146,7 +146,7 @@ describe("Small Test ThingIFAPI#patchCommandTrigger", function() {
 })
 
 describe("Small Test ThingIFAPI#patchServerCodeTrigger", function() {
-    let request = new ServerCodeTriggerRequest(serverCode, predicate);
+    let request = new PatchServerCodeTriggerRequest(serverCode, predicate);
     describe("handle IllegalStateError", function() {
         let thingIFAPI = new ThingIFAPI(owner, ownerToken, testApp.app);
         it("when targe is null, IllegalStateError should be returned(promise)",

--- a/test/small/ThingIFAPITriggerTests/PostTriggerTest.ts
+++ b/test/small/ThingIFAPITriggerTests/PostTriggerTest.ts
@@ -8,7 +8,7 @@ import TestApp from '../TestApp'
 import {ThingIFAPI} from '../../../src/ThingIFAPI';
 import {TypedID} from '../../../src/TypedID';
 import {Types} from '../../../src/TypedID';
-import {CommandTriggerRequest, ServerCodeTriggerRequest, ListQueryOptions} from '../../../src/RequestObjects';
+import {PostCommandTriggerRequest, PostServerCodeTriggerRequest, ListQueryOptions, TriggerCommandObject} from '../../../src/RequestObjects';
 import TriggerOps from '../../../src/ops/TriggerOps'
 import {Trigger, TriggersWhen, TriggersWhat} from '../../../src/Trigger';
 import {Command, CommandState} from '../../../src/Command';
@@ -31,7 +31,7 @@ let predicate = new StatePredicate(condition, TriggersWhen.CONDITION_CHANGED);
 let serverCode = new ServerCode("server_function", ownerToken, testApp.appID, {brightness : 100, color : "#FFF"});
 
 describe("Small Test ThingIFAPI#postCommandTrigger", function() {
-    let request = new CommandTriggerRequest(schema, schemaVersion, target, actions, predicate, owner);
+    let request = new PostCommandTriggerRequest(new TriggerCommandObject(schema, schemaVersion, actions, target, owner), predicate);
     describe("handle IllegalStateError", function() {
         let thingIFAPI = new ThingIFAPI(owner, ownerToken, testApp.app);
         it("when targe is null, IllegalStateError should be returned(promise)",
@@ -147,7 +147,7 @@ describe("Small Test ThingIFAPI#postCommandTrigger", function() {
 })
 
 describe("Small Test ThingIFAPI#postServerCodeTrigger", function() {
-    let request = new ServerCodeTriggerRequest(serverCode, predicate);
+    let request = new PostServerCodeTriggerRequest(serverCode, predicate);
     describe("handle IllegalStateError", function() {
         let thingIFAPI = new ThingIFAPI(owner, ownerToken, testApp.app);
         it("when targe is null, IllegalStateError should be returned(promise)",

--- a/test/small/TriggerOpsTest.ts
+++ b/test/small/TriggerOpsTest.ts
@@ -35,7 +35,7 @@ let au = new APIAuthor(ownerToken, testApp.app);
 let triggerOps = new TriggerOps(au, target);
 let commandTarget = new TypedID(Types.Thing, "th.2355-eftef");
 
-describe.only('Test TriggerOps', function () {
+describe('Test TriggerOps', function () {
 
     beforeEach(function() {
         nock.cleanAll();

--- a/test/small/TriggerOpsTest.ts
+++ b/test/small/TriggerOpsTest.ts
@@ -887,7 +887,6 @@ describe('Test TriggerOps', function () {
                 new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject("", 1, [{turnPower: {power:true}}], target), predicate), Errors.ArgumentError, "schema of command is null or empty", "should handle error when schema is empty"),
                 new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject("led", null, [{turnPower: {power:true}}], target), predicate), Errors.ArgumentError, "schemaVersion of command is null", "should handle error when schemaVersion is null"),
                 new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject("led", 1, null, target), null), Errors.ArgumentError, "actions of command is null", "should handle error when actions and predicate are null"),
-                new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], null), predicate), Errors.ArgumentError, "targetID of command is null", "should handle error when commandTrigger is null"),
             ]
             tests.forEach(function(test) {
                 it(test.description, function(done){

--- a/test/small/TriggerOpsTest.ts
+++ b/test/small/TriggerOpsTest.ts
@@ -8,7 +8,14 @@ import TestApp from './TestApp'
 import {APIAuthor} from '../../src/APIAuthor';
 import {TypedID} from '../../src/TypedID';
 import {Types} from '../../src/TypedID';
-import {CommandTriggerRequest, ServerCodeTriggerRequest, ListQueryOptions} from '../../src/RequestObjects';
+import {
+    PostCommandTriggerRequest,
+    PatchCommandTriggerRequest,
+    PostServerCodeTriggerRequest,
+    PatchServerCodeTriggerRequest,
+    ListQueryOptions,
+    TriggerCommandObject
+} from '../../src/RequestObjects';
 import TriggerOps from '../../src/ops/TriggerOps'
 import {Trigger, TriggersWhen, TriggersWhat} from '../../src/Trigger';
 import {Command, CommandState} from '../../src/Command';
@@ -28,7 +35,7 @@ let au = new APIAuthor(ownerToken, testApp.app);
 let triggerOps = new TriggerOps(au, target);
 let commandTarget = new TypedID(Types.Thing, "th.2355-eftef");
 
-describe('Test TriggerOps', function () {
+describe.only('Test TriggerOps', function () {
 
     beforeEach(function() {
         nock.cleanAll();
@@ -147,6 +154,7 @@ describe('Test TriggerOps', function () {
 
     describe('#postCommandTrigger() with promise', function () {
         let postCommandTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers`;
+        let commandRequest = new TriggerCommandObject(schema, schemaVersion, actions, target, owner);
         it("with StatePredicate", function (done) {
             nock(
                 testApp.site,
@@ -174,8 +182,7 @@ describe('Test TriggerOps', function () {
                     }
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
-
-            let request = new CommandTriggerRequest(schema, schemaVersion, target, actions, statePredicate, owner);
+            let request = new PostCommandTriggerRequest(commandRequest, statePredicate);
             triggerOps.postCommandTrigger(request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -222,7 +229,7 @@ describe('Test TriggerOps', function () {
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
 
-            let request = new CommandTriggerRequest(schema, schemaVersion, target, actions, schedulePredicate, owner);
+            let request = new PostCommandTriggerRequest(commandRequest, schedulePredicate);
             triggerOps.postCommandTrigger(request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -268,7 +275,7 @@ describe('Test TriggerOps', function () {
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
 
-            let request = new CommandTriggerRequest(schema, schemaVersion, target, actions, scheduleOncePredicate, owner);
+            let request = new PostCommandTriggerRequest(commandRequest, scheduleOncePredicate);
             triggerOps.postCommandTrigger(request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -321,7 +328,7 @@ describe('Test TriggerOps', function () {
                 })
                 .reply(400, errResponse, {"Content-Type": "application/json"});
 
-            let request = new CommandTriggerRequest(schema, schemaVersion, target, actions, statePredicate, owner);
+            let request = new PostCommandTriggerRequest(commandRequest, statePredicate);
             triggerOps.postCommandTrigger(request).then((trigger:Trigger)=>{
                 done("should fail");
             }).catch((err:HttpRequestError)=>{
@@ -336,7 +343,7 @@ describe('Test TriggerOps', function () {
         describe("Argument Test", function() {
             class TestCase {
                 constructor(
-                    public request: CommandTriggerRequest,
+                    public request: PostCommandTriggerRequest,
                     public expectedError: string,
                     public expectedErrorMsg: string,
                     public description: string
@@ -345,13 +352,13 @@ describe('Test TriggerOps', function () {
             let predicate = new ScheduleOncePredicate(new Date().getTime());
             let tests = [
                 new TestCase(null, Errors.ArgumentError, "requestObject is null", "should handle error when requestObject is null"),
-                new TestCase(new CommandTriggerRequest(null, 1, target, [{turnPower: {power:true}}], predicate, owner), Errors.ArgumentError, "schema is null or empty", "should handle error when schema is null"),
-                new TestCase(new CommandTriggerRequest("", 1, target, [{turnPower: {power:true}}], predicate, owner), Errors.ArgumentError, "schema is null or empty", "should handle error when schema is empty"),
-                new TestCase(new CommandTriggerRequest("led", null, target, [{turnPower: {power:true}}], predicate, owner), Errors.ArgumentError, "schemaVersion is null", "should handle error when schemaVersion is null"),
-                new TestCase(new CommandTriggerRequest("led", 1, target, null, predicate, owner), Errors.ArgumentError, "actions is null", "should handle error when actions is null"),
-                new TestCase(new CommandTriggerRequest("led", 1, target, [{turnPower: {power:true}}], null, owner), Errors.ArgumentError, "predicate is null", "should handle error when predicate is null"),
-                new TestCase(new CommandTriggerRequest("led", 1, null, [{turnPower: {power:true}}], predicate, owner), Errors.ArgumentError, "commandTarget is null", "should handle error when commandTarget is null"),
-                new TestCase(new CommandTriggerRequest("led", 1, target, [{turnPower: {power:true}}], predicate, null), Errors.ArgumentError, "issuerID is null", "should handle error when issuerID is null"),
+                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject(null, 1, [{turnPower: {power:true}}], target, owner), predicate), Errors.ArgumentError, "schema of command is null or empty", "should handle error when schema is null"),
+                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("", 1, [{turnPower: {power:true}}], target, owner), predicate), Errors.ArgumentError, "schema of command is null or empty", "should handle error when schema is empty"),
+                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", null, [{turnPower: {power:true}}], target, owner), predicate), Errors.ArgumentError, "schemaVersion of command is null", "should handle error when schemaVersion is null"),
+                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, null, target, owner), predicate), Errors.ArgumentError, "actions of command is null", "should handle error when actions is null"),
+                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], target, owner), null), Errors.ArgumentError, "predicate is null", "should handle error when predicate is null"),
+                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], null, owner), predicate), Errors.ArgumentError, "targetID of command is null", "should handle error when commandTarget is null"),
+                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], target, null), predicate), Errors.ArgumentError, "issuerID of command is null", "should handle error when issuerID is null"),
             ]
             tests.forEach(function(test) {
                 it(test.description, function(done){
@@ -373,6 +380,8 @@ describe('Test TriggerOps', function () {
     });
     describe('#postCommandTrigger() with promise(cross thing command trigger)', function () {
         let postCommandTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers`;
+        let commandRequest = new TriggerCommandObject(schema, schemaVersion, actions, commandTarget, owner);
+
         it("with StatePredicate", function (done) {
             nock(
                 testApp.site,
@@ -401,7 +410,7 @@ describe('Test TriggerOps', function () {
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
 
-            let request = new CommandTriggerRequest(schema, schemaVersion, commandTarget, actions, statePredicate, owner);
+            let request = new PostCommandTriggerRequest(commandRequest, statePredicate);
             triggerOps.postCommandTrigger(request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -453,7 +462,7 @@ describe('Test TriggerOps', function () {
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
 
-            let request = new ServerCodeTriggerRequest(serverCode, statePredicate);
+            let request = new PostServerCodeTriggerRequest(serverCode, statePredicate);
             triggerOps.postServerCodeTrigger(request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -498,7 +507,7 @@ describe('Test TriggerOps', function () {
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
 
-            let request = new ServerCodeTriggerRequest(serverCode, schedulePredicate);
+            let request = new PostServerCodeTriggerRequest(serverCode, schedulePredicate);
             triggerOps.postServerCodeTrigger(request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -542,7 +551,7 @@ describe('Test TriggerOps', function () {
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
 
-            let request = new ServerCodeTriggerRequest(serverCode, scheduleOncePredicate);
+            let request = new PostServerCodeTriggerRequest(serverCode, scheduleOncePredicate);
             triggerOps.postServerCodeTrigger(request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -593,7 +602,7 @@ describe('Test TriggerOps', function () {
                 })
                 .reply(400, errResponse, {"Content-Type": "application/json"});
 
-            let request = new ServerCodeTriggerRequest(serverCode, statePredicate);
+            let request = new PostServerCodeTriggerRequest(serverCode, statePredicate);
             triggerOps.postServerCodeTrigger(request).then((trigger:Trigger)=>{
                 done("should fail");
             }).catch((err:HttpRequestError)=>{
@@ -608,7 +617,7 @@ describe('Test TriggerOps', function () {
         describe("Argument Test", function() {
             class TestCase {
                 constructor(
-                    public request: ServerCodeTriggerRequest,
+                    public request: PostServerCodeTriggerRequest,
                     public expectedError: string,
                     public expectedErrorMsg: string,
                     public description: string
@@ -618,8 +627,8 @@ describe('Test TriggerOps', function () {
             let predicate = new ScheduleOncePredicate(new Date().getTime());
             let tests = [
                 new TestCase(null, Errors.ArgumentError, "requestObject is null", "should handle error when requestObject is null"),
-                new TestCase(new ServerCodeTriggerRequest(null, predicate), Errors.ArgumentError, "serverCode is null", "should handle error when serverCode is null"),
-                new TestCase(new ServerCodeTriggerRequest(serverCode, null), Errors.ArgumentError, "predicate is null", "should handle error when predicate is null"),
+                new TestCase(new PostServerCodeTriggerRequest(null, predicate), Errors.ArgumentError, "serverCode is null", "should handle error when serverCode is null"),
+                new TestCase(new PostServerCodeTriggerRequest(serverCode, null), Errors.ArgumentError, "predicate is null", "should handle error when predicate is null"),
             ]
             tests.forEach(function(test) {
                 it(test.description, function(done){
@@ -645,6 +654,7 @@ describe('Test TriggerOps', function () {
         // 2. GET  `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`
         let patchCommandTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`;
         let getTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`;
+        let commandRequest = new TriggerCommandObject(schema, schemaVersion, actions, target, owner);
         it("with StatePredicate", function (done) {
             nock(
                 testApp.site,
@@ -682,7 +692,7 @@ describe('Test TriggerOps', function () {
                 }).get(getTriggerPath)
                 .reply(200, responseBody4CommandTriggerWithState, {"Content-Type": "application/json"});
 
-            let request = new CommandTriggerRequest(schema, schemaVersion, target, actions, statePredicate, owner);
+            let request = new PatchCommandTriggerRequest(commandRequest, statePredicate);
             triggerOps.patchCommandTrigger(expectedTriggerID, request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -738,7 +748,7 @@ describe('Test TriggerOps', function () {
                 }).get(getTriggerPath)
                 .reply(200, responseBody4CommandTriggerWithSchedule, {"Content-Type": "application/json"});
 
-            let request = new CommandTriggerRequest(schema, schemaVersion, target, actions, schedulePredicate, owner);
+            let request = new PatchCommandTriggerRequest(commandRequest, schedulePredicate);
             triggerOps.patchCommandTrigger(expectedTriggerID, request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -793,7 +803,7 @@ describe('Test TriggerOps', function () {
                 }).get(getTriggerPath)
                 .reply(200, responseBody4CommandTriggerWithScheduleOnce, {"Content-Type": "application/json"});
 
-            let request = new CommandTriggerRequest(schema, schemaVersion, target, actions, scheduleOncePredicate, owner);
+            let request = new PatchCommandTriggerRequest(commandRequest, scheduleOncePredicate);
             triggerOps.patchCommandTrigger(expectedTriggerID, request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -846,7 +856,7 @@ describe('Test TriggerOps', function () {
                 })
                 .reply(400, errResponse, {"Content-Type": "application/json"});
 
-            let request = new CommandTriggerRequest(schema, schemaVersion, target, actions, statePredicate, owner);
+            let request = new PatchCommandTriggerRequest(commandRequest, statePredicate);
             triggerOps.patchCommandTrigger(expectedTriggerID, request).then((trigger:Trigger)=>{
                 done("should fail");
             }).catch((err:HttpRequestError)=>{
@@ -862,7 +872,7 @@ describe('Test TriggerOps', function () {
             class TestCase {
                 constructor(
                     public triggerID: string,
-                    public request: CommandTriggerRequest,
+                    public request: PatchCommandTriggerRequest,
                     public expectedError: string,
                     public expectedErrorMsg: string,
                     public description: string
@@ -870,14 +880,14 @@ describe('Test TriggerOps', function () {
             }
             let predicate = new ScheduleOncePredicate(new Date().getTime());
             let tests = [
-                new TestCase(null, new CommandTriggerRequest("led", 1, target, [{turnPower: {power:true}}], predicate), Errors.ArgumentError, "triggerID is null or empty", "should handle error when triggerID is null"),
-                new TestCase("", new CommandTriggerRequest("led", 1, target, [{turnPower: {power:true}}], predicate), Errors.ArgumentError, "triggerID is null or empty", "should handle error when triggerID is empty"),
+                new TestCase(null, new PatchCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], target), predicate), Errors.ArgumentError, "triggerID is null or empty", "should handle error when triggerID is null"),
+                new TestCase("", new PatchCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], target), predicate), Errors.ArgumentError, "triggerID is null or empty", "should handle error when triggerID is empty"),
                 new TestCase("trigger-01234-abcd", null, Errors.ArgumentError, "requestObject is null", "should handle error when requestObject is null"),
-                new TestCase("trigger-01234-abcd", new CommandTriggerRequest(null, 1, target, [{turnPower: {power:true}}], predicate), Errors.ArgumentError, "schema is null or empty", "should handle error when schema is null"),
-                new TestCase("trigger-01234-abcd", new CommandTriggerRequest("", 1, target, [{turnPower: {power:true}}], predicate), Errors.ArgumentError, "schema is null or empty", "should handle error when schema is empty"),
-                new TestCase("trigger-01234-abcd", new CommandTriggerRequest("led", null, target, [{turnPower: {power:true}}], predicate), Errors.ArgumentError, "schemaVersion is null", "should handle error when schemaVersion is null"),
-                new TestCase("trigger-01234-abcd", new CommandTriggerRequest("led", 1, target, null, null), Errors.ArgumentError, "must specify actions or predicate", "should handle error when actions and predicate are null"),
-                new TestCase("trigger-01234-abcd", new CommandTriggerRequest("led", 1, null, null, predicate), Errors.ArgumentError, "commandTarget is null", "should handle error when commandTrigger is null"),
+                new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject(null, 1, [{turnPower: {power:true}}], target), predicate), Errors.ArgumentError, "schema of command is null or empty", "should handle error when schema is null"),
+                new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject("", 1, [{turnPower: {power:true}}], target), predicate), Errors.ArgumentError, "schema of command is null or empty", "should handle error when schema is empty"),
+                new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject("led", null, [{turnPower: {power:true}}], target), predicate), Errors.ArgumentError, "schemaVersion of command is null", "should handle error when schemaVersion is null"),
+                new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject("led", 1, null, target), null), Errors.ArgumentError, "actions of command is null", "should handle error when actions and predicate are null"),
+                new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], null), predicate), Errors.ArgumentError, "targetID of command is null", "should handle error when commandTrigger is null"),
             ]
             tests.forEach(function(test) {
                 it(test.description, function(done){
@@ -960,7 +970,7 @@ describe('Test TriggerOps', function () {
                 }).get(getTriggerPath)
                 .reply(200, responseBody4CrossThingCommandTriggerWithState, {"Content-Type": "application/json"});
 
-            let request = new CommandTriggerRequest(schema, schemaVersion, commandTarget, actions, statePredicate, owner);
+            let request = new PatchCommandTriggerRequest(new TriggerCommandObject(schema, schemaVersion, actions, commandTarget, owner), statePredicate);
             triggerOps.patchCommandTrigger(expectedTriggerID, request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -1025,7 +1035,7 @@ describe('Test TriggerOps', function () {
                 }).get(getTriggerPath)
                 .reply(200, responseBody4ServerCodeTriggerWithState, {"Content-Type": "application/json"});
 
-            let request = new ServerCodeTriggerRequest(serverCode, statePredicate);
+            let request = new PatchServerCodeTriggerRequest(serverCode, statePredicate);
             triggerOps.patchServerCodeTrigger(expectedTriggerID, request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -1079,7 +1089,7 @@ describe('Test TriggerOps', function () {
                 }).get(getTriggerPath)
                 .reply(200, responseBody4ServerCodeTriggerWithSchedule, {"Content-Type": "application/json"});
 
-            let request = new ServerCodeTriggerRequest(serverCode, schedulePredicate);
+            let request = new PatchServerCodeTriggerRequest(serverCode, schedulePredicate);
             triggerOps.patchServerCodeTrigger(expectedTriggerID, request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -1132,7 +1142,7 @@ describe('Test TriggerOps', function () {
                 }).get(getTriggerPath)
                 .reply(200, responseBody4ServerCodeTriggerWithScheduleOnce, {"Content-Type": "application/json"});
 
-            let request = new ServerCodeTriggerRequest(serverCode, scheduleOncePredicate);
+            let request = new PatchServerCodeTriggerRequest(serverCode, scheduleOncePredicate);
             triggerOps.patchServerCodeTrigger(expectedTriggerID, request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -1183,7 +1193,7 @@ describe('Test TriggerOps', function () {
                 })
                 .reply(400, errResponse, {"Content-Type": "application/json"});
 
-            let request = new ServerCodeTriggerRequest(serverCode, statePredicate);
+            let request = new PatchServerCodeTriggerRequest(serverCode, statePredicate);
             triggerOps.patchServerCodeTrigger(expectedTriggerID, request).then((trigger:Trigger)=>{
                 done("should fail");
             }).catch((err:HttpRequestError)=>{
@@ -1199,7 +1209,7 @@ describe('Test TriggerOps', function () {
             class TestCase {
                 constructor(
                     public triggerID: string,
-                    public request: ServerCodeTriggerRequest,
+                    public request: PatchServerCodeTriggerRequest,
                     public expectedError: string,
                     public expectedErrorMsg: string,
                     public description: string
@@ -1208,10 +1218,10 @@ describe('Test TriggerOps', function () {
             let serverCode = new ServerCode("servercode_func");
             let predicate = new ScheduleOncePredicate(new Date().getTime());
             let tests = [
-                new TestCase(null, new ServerCodeTriggerRequest(null, predicate), Errors.ArgumentError, "triggerID is null or empty", "should handle error when triggerID is null"),
-                new TestCase("", new ServerCodeTriggerRequest(serverCode, null), Errors.ArgumentError, "triggerID is null or empty", "should handle error when triggerID is empty"),
+                new TestCase(null, new PatchServerCodeTriggerRequest(null, predicate), Errors.ArgumentError, "triggerID is null or empty", "should handle error when triggerID is null"),
+                new TestCase("", new PatchServerCodeTriggerRequest(serverCode, null), Errors.ArgumentError, "triggerID is null or empty", "should handle error when triggerID is empty"),
                 new TestCase("trigger-01234-abcd", null, Errors.ArgumentError, "requestObject is null", "should handle error when requestObject is null"),
-                new TestCase("trigger-01234-abcd", new ServerCodeTriggerRequest(null, null), Errors.ArgumentError, "must specify serverCode or predicate", "should handle error when serverCode and predicate are null"),
+                new TestCase("trigger-01234-abcd", new PatchServerCodeTriggerRequest(null, null), Errors.ArgumentError, "must specify serverCode or predicate", "should handle error when serverCode and predicate are null"),
             ]
             tests.forEach(function(test) {
                 it(test.description, function(done){


### PR DESCRIPTION
### Description
Since the required fields  for creating trigger and updating trigger are different. It will be clear to provide seperate class for each operation(create or update). 

### Changes in APIs

#### Change
- make TriggerCommandObject.targetID optional
  - PostCommandTrigger will use resource thing by default.
  - PathCommandTrigger will not update if it is null.

#### Deprecated
- CommandTriggerRequest
- ServerCodeTriggerRequest

#### New class
- TrggerCommandObject: used as a property in PostCommandTriggerRequest and PatchCommandTriggerRequest.
- PostCommandTriggerRequest: used in ThingIFAPI/APIAuthor.PostCommandTrigger
- PatchCommandTriggerRequest: used in ThingIFAPI/APIAuthor.PatchCommandTrigger
- PostServercodeTriggerRequest: used in ThingIFAPI/APIAuthor.PostServercodeTrigger
- PatchServercodeTriggerRequest: used in ThingIFAPI/APIAuthor.PatchServercodeTrigger

