### PR TITLE
Optional command target

### DIFF
--- a/src/RequestObjects.ts
+++ b/src/RequestObjects.ts
@@ -265,7 +265,7 @@ export class TriggerCommandObject {
      * @param {string} schema Name of schema.
      * @param {number} schemaVersion Version number of schema.
      * @param {number[]} actions Array of actions of the command.
-     * @param {TypedID} targetID instance of TypedID to represent target of command.
+     * @param {TypedID} [targetID] instance of TypedID to represent target of command.
      * @param {TypedID} [issuerID] instance of TypedID to represent issuer of command.
      * @param {string} [title] Title of the command.
      * @param {string} [description] Description of the command.
@@ -275,7 +275,7 @@ export class TriggerCommandObject {
         schema: string,
         schemaVersion: number,
         actions: Array<Object>,
-        targetID: TypedID,
+        targetID?: TypedID,
         issuerID?: TypedID,
         title?: string,
         description?: string,

--- a/src/ops/TriggerOps.ts
+++ b/src/ops/TriggerOps.ts
@@ -54,10 +54,7 @@ export default class TriggerOps extends BaseOp {
                 reject(new ThingIFError(Errors.ArgumentError, "actions of command is null"));
                 return;
             }
-            if (!commandRequest.targetID) {
-                reject(new ThingIFError(Errors.ArgumentError, "targetID of command is null"));
-                return;
-            }
+
             if (!requestObject.predicate) {
                 reject(new ThingIFError(Errors.ArgumentError, "predicate is null"));
                 return;

--- a/test/small/TriggerOpsTest.ts
+++ b/test/small/TriggerOpsTest.ts
@@ -358,6 +358,7 @@ describe('Test TriggerOps', function () {
                 new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, null, target, owner), predicate), Errors.ArgumentError, "actions of command is null", "should handle error when actions is null"),
                 new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], target, owner), null), Errors.ArgumentError, "predicate is null", "should handle error when predicate is null"),
                 new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], target, null), predicate), Errors.ArgumentError, "issuerID of command is null", "should handle error when issuerID is null"),
+                new TestCase(new PostCommandTriggerRequest(null, predicate), Errors.ArgumentError, "command is null", "should handle error when command is null"),
             ]
             tests.forEach(function(test) {
                 it(test.description, function(done){

--- a/test/small/TriggerOpsTest.ts
+++ b/test/small/TriggerOpsTest.ts
@@ -357,7 +357,6 @@ describe('Test TriggerOps', function () {
                 new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", null, [{turnPower: {power:true}}], target, owner), predicate), Errors.ArgumentError, "schemaVersion of command is null", "should handle error when schemaVersion is null"),
                 new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, null, target, owner), predicate), Errors.ArgumentError, "actions of command is null", "should handle error when actions is null"),
                 new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], target, owner), null), Errors.ArgumentError, "predicate is null", "should handle error when predicate is null"),
-                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], null, owner), predicate), Errors.ArgumentError, "targetID of command is null", "should handle error when commandTarget is null"),
                 new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], target, null), predicate), Errors.ArgumentError, "issuerID of command is null", "should handle error when issuerID is null"),
             ]
             tests.forEach(function(test) {


### PR DESCRIPTION
In released 0.2.2, targetID of TriggerCommandObject supposed to be optional. This PR improve the implementation to achieve it.  