### PR TITLE
Windows compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ If succeeded, uglified library file named `thing-if-sdk.min.js` is available und
   $ cd thing-if-JSSDK
   $ npm install
   $ npm install browserify -g
-  $ npm run build-lib
   $ browserify . -s ThingIF > thing-if-sdk.js
   ```
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ If succeeded, uglified library file named `thing-if-sdk.min.js` is available und
   browserify bundles all the dependencies into a single file.
   ```
   $ cd thing-if-JSSDK
+  $ npm install
   $ npm install browserify -g
   $ npm run build-lib
   $ browserify . -s ThingIF > thing-if-sdk.js

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "build-test": "tsc test/*/*Test.ts test/*/*/*Test.ts ./typings/globals/node/index.d.ts --target es5 --module commonjs --outDir built",
     "pretest": "npm run build-test",
     "test": "mocha 'built/test/*/*.js' 'built/test/*/*/*.js' --timeout 20000",
-    "test-cov": "npm run build-test; istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec 'built/test/small/*.js' 'built/test/small/*/*.js' && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
-    "test-cov-local": "npm run build-test; istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec 'built/test/small/*.js' 'built/test/small/*/*.js'; open coverage/lcov-report/index.html",
-    "small-test": "npm run build-test; mocha 'built/test/small/*.js' 'built/test/small/*/*.js'",
-    "large-test": "npm run build-test; mocha 'built/test/large/*.js' --timeout 20000",
-    "build-lib": "rm -fr built; rm -fr lib; tsc; cp -fr built lib",
+    "test-cov": "npm run build-test && istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec 'built/test/small/*.js' 'built/test/small/*/*.js' && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+    "test-cov-local": "npm run build-test && istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec 'built/test/small/*.js' 'built/test/small/*/*.js'&& open coverage/lcov-report/index.html",
+    "small-test": "npm run build-test && mocha 'built/test/small/*.js' 'built/test/small/*/*.js'",
+    "large-test": "npm run build-test && mocha 'built/test/large/*.js' --timeout 20000",
+    "build-lib": "rm -fr built && rm -fr lib && tsc && cp -fr built lib",
     "prepublish": "typings install && npm run build-lib"
   },
   "repository": {


### PR DESCRIPTION
- npm script with semicolon(;) can not run well on windows. Fixed by replace semicolon(;) with &&
- fixed readme about `Use thing-if-sdk in browser app`