### PR TITLE
Test TriggerOps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "LICENSE.txt"
   ],
   "scripts": {
-    "build-test": "rm -fr built && npm run build-src && tsc test/*/*Test.ts test/*/*/*Test.ts ./typings/globals/node/index.d.ts --target es5 --module commonjs --outDir built",
+    "build-test": "rm -fr built && npm run build-src && tsc test/*/*Test.ts ./typings/globals/node/index.d.ts --target es5 --module commonjs --outDir built",
     "pretest": "npm run build-test",
     "test": "mocha 'built/test/*/*.js' 'built/test/*/*/*.js' --timeout 20000",
     "test-cov": "npm run build-test && istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec 'built/test/small/*.js' 'built/test/small/*/*.js' && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "LICENSE.txt"
   ],
   "scripts": {
-    "build-test": "npm run build-src && tsc test/*/*Test.ts ./typings/globals/node/index.d.ts --target es5 --module commonjs --outDir built",
+    "build-test": "rm -fr built && npm run build-src && tsc test/*/*Test.ts test/*/*/*Test.ts ./typings/globals/node/index.d.ts --target es5 --module commonjs --outDir built",
     "pretest": "npm run build-test",
     "test": "mocha 'built/test/*/*.js' 'built/test/*/*/*.js' --timeout 20000",
     "test-cov": "npm run build-test && istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec 'built/test/small/*.js' 'built/test/small/*/*.js' && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -50,39 +50,6 @@ export class Command {
     ) {}
 
     /**
-     * This method is for internal use only.
-     * @return {Object} JSON object that represented this instance.
-     */
-    toJson(): any {
-        var jsonObject: any ={};
-        if(!!this.commandID){
-            jsonObject.commandID = this.commandID
-        }
-        if(!!this.targetID){
-            jsonObject.target = this.targetID.toString();
-        }
-        if(!!this.issuerID){
-            jsonObject.issuer = this.issuerID.toString();
-        }
-        if(!!this.aliasActions){
-            jsonObject.actions = this.aliasActions;
-        }
-        if(!!this.aliasActionResults){
-            jsonObject.actionResults = this.aliasActionResults;
-        }
-        if(!!this.title){
-            jsonObject.title = this.title;
-        }
-        if(!!this.description){
-            jsonObject.description = this.description;
-        }
-        if(!!this.metadata){
-            jsonObject.metadata = this.metadata;
-        }
-        return jsonObject;
-    }
-
-    /**
      * Retrieve aliasAction with specified alias.
      * @param {string} alias alias name.
      * @return {Array<AliasAction>} Found array of AliasAction object. If there is not

--- a/src/RequestObjects.ts
+++ b/src/RequestObjects.ts
@@ -210,13 +210,6 @@ export class ListQueryOptions {
  * @prop {Object} metadata Key-value list to store within command definition.
  */
 export class TriggerCommandObject {
-    public aliasActions: Array<AliasAction>;
-    public issuerID: TypedID;
-    public targetID: TypedID;
-    public title: string;
-    public description: string;
-    public metadata: Object;
-
     /**
      * Create a PostCommandRequest.
      * @constructor
@@ -228,19 +221,12 @@ export class TriggerCommandObject {
      * @param {Object} [metadata] Key-value list to store within command definition.
      */
     constructor(
-        aliasActions: Array<AliasAction>,
-        targetID?: TypedID,
-        issuerID?: TypedID,
-        title?: string,
-        description?: string,
-        metadata?: Object) {
-            this.aliasActions = aliasActions;
-            this.targetID = targetID;
-            this.issuerID = issuerID;
-            this.title = title;
-            this.description = description;
-            this.metadata = metadata;
-        }
+        public aliasActions: Array<AliasAction>,
+        public targetID?: TypedID,
+        public issuerID?: TypedID,
+        public title?: string,
+        public description?: string,
+        public metadata?: Object) {}
 }
 /**
  * Represents the request for creating a command trigger.

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -52,28 +52,6 @@ export class Trigger {
         }
         return TriggersWhat.SERVER_CODE;
     }
-
-    /**
-     * This method is for internal use only.
-     * @param obj JSON object that represented a trigger.
-     * @return {Trigger} Trigger instance
-     */
-    static fromJson(obj: any): Trigger {
-        //TODO: will move this method to JsonUtilities
-        // let predicate: Predicate = Predicate.fromJson(obj.predicate);
-        // let command: Command = obj.command ? Command.fromJson(obj.command) : null;
-        // let serverCode: ServerCode = obj.serverCode ? ServerCode.fromJson(obj.serverCode) : null;
-        // let trigger = new Trigger(predicate, command, serverCode);
-        // trigger.triggerID = obj.triggerID ? obj.triggerID : null;
-        // trigger.disabled = obj.disabled === undefined ?  null : obj.disabled;
-        // trigger.disabledReason = obj.disabledReason ? obj.disabledReason : null;
-        // trigger.title = obj.title ? obj.title : null;
-        // trigger.description = obj.description ? obj.description : null;
-        // trigger.metadata = obj.metadata ? obj.metadata : null;
-        // return trigger;
-        return null;
-    }
-
 }
 /** Represents the type of condition to fire a trigger.
 <ul>

--- a/src/internal/JsonUtilities.ts
+++ b/src/internal/JsonUtilities.ts
@@ -12,6 +12,9 @@ import {
     OrClauseInTrigger
 } from '../TriggerClause';
 import { TriggerCommandObject } from '../RequestObjects';
+import { Trigger } from '../Trigger';
+import { Predicate } from '../Predicate';
+import { ServerCode } from '../ServerCode';
 
 export function actionToJson(action: Action): Object {
     if (!!action && !!action.name) {
@@ -301,4 +304,18 @@ export function triggeredCommandToJson(cmd: TriggerCommandObject): Object {
         return jsonObject;
     }
     return null;
+}
+
+export function jsonToTrigger(obj: any): Trigger {
+        let predicate: Predicate = Predicate.fromJson(obj.predicate);
+        let command: Command = obj.command ? jsonToCommand(obj.command) : null;
+        let serverCode: ServerCode = obj.serverCode ? ServerCode.fromJson(obj.serverCode) : null;
+        let trigger = new Trigger(predicate, command, serverCode);
+        trigger.triggerID = obj.triggerID ? obj.triggerID : null;
+        trigger.disabled = obj.disabled === undefined ?  null : obj.disabled;
+        trigger.disabledReason = obj.disabledReason ? obj.disabledReason : null;
+        trigger.title = obj.title ? obj.title : null;
+        trigger.description = obj.description ? obj.description : null;
+        trigger.metadata = obj.metadata ? obj.metadata : null;
+        return trigger;
 }

--- a/src/internal/JsonUtilities.ts
+++ b/src/internal/JsonUtilities.ts
@@ -307,15 +307,17 @@ export function triggeredCommandToJson(cmd: TriggerCommandObject): Object {
 }
 
 export function jsonToTrigger(obj: any): Trigger {
-        let predicate: Predicate = Predicate.fromJson(obj.predicate);
-        let command: Command = obj.command ? jsonToCommand(obj.command) : null;
-        let serverCode: ServerCode = obj.serverCode ? ServerCode.fromJson(obj.serverCode) : null;
-        let trigger = new Trigger(predicate, command, serverCode);
-        trigger.triggerID = obj.triggerID ? obj.triggerID : null;
-        trigger.disabled = obj.disabled === undefined ?  null : obj.disabled;
-        trigger.disabledReason = obj.disabledReason ? obj.disabledReason : null;
-        trigger.title = obj.title ? obj.title : null;
-        trigger.description = obj.description ? obj.description : null;
-        trigger.metadata = obj.metadata ? obj.metadata : null;
-        return trigger;
+    // TODO: need to move Predicate.fromJson
+    let predicate: Predicate = Predicate.fromJson(obj.predicate);
+    let command: Command = obj.command ? jsonToCommand(obj.command) : null;
+    // TODO: need to move ServerCode.fromJson
+    let serverCode: ServerCode = obj.serverCode ? ServerCode.fromJson(obj.serverCode) : null;
+    let trigger = new Trigger(predicate, command, serverCode);
+    trigger.triggerID = obj.triggerID ? obj.triggerID : null;
+    trigger.disabled = obj.disabled === undefined ? null : obj.disabled;
+    trigger.disabledReason = obj.disabledReason ? obj.disabledReason : null;
+    trigger.title = obj.title ? obj.title : null;
+    trigger.description = obj.description ? obj.description : null;
+    trigger.metadata = obj.metadata ? obj.metadata : null;
+    return trigger;
 }

--- a/src/internal/JsonUtilities.ts
+++ b/src/internal/JsonUtilities.ts
@@ -11,6 +11,7 @@ import {
     AndClauseInTrigger,
     OrClauseInTrigger
 } from '../TriggerClause';
+import { TriggerCommandObject } from '../RequestObjects';
 
 export function actionToJson(action: Action): Object {
     if (!!action && !!action.name) {
@@ -278,6 +279,26 @@ export function triggerClauseToJson(clause: TriggerClause): Object {
             type: "or",
             clauses: jsonArray
         };
+    }
+    return null;
+}
+export function triggeredCommandToJson(cmd: TriggerCommandObject): Object {
+    if (!!cmd.targetID && isArray(cmd.aliasActions) && !!cmd.issuerID) {
+        var jsonObject: any = {};
+        jsonObject.target = cmd.targetID.toString();
+        jsonObject.issuer = cmd.issuerID.toString();
+        jsonObject.actions = aliasActonArrayToJsons(cmd.aliasActions);
+
+        if (!!cmd.title) {
+            jsonObject.title = cmd.title;
+        }
+        if (!!cmd.description) {
+            jsonObject.description = cmd.description;
+        }
+        if (!!cmd.metadata) {
+            jsonObject.metadata = cmd.metadata;
+        }
+        return jsonObject;
     }
     return null;
 }

--- a/src/ops/TriggerOps.ts
+++ b/src/ops/TriggerOps.ts
@@ -178,7 +178,7 @@ export default class TriggerOps extends BaseOp {
                 url: url
             };
             request(req).then((res: Response)=>{
-                resolve(Trigger.fromJson((<any>res).body));
+                resolve(JsonUtils.jsonToTrigger((<any>res).body));
             }).catch((err)=>{
                 reject(err);
             });
@@ -382,7 +382,7 @@ export default class TriggerOps extends BaseOp {
                 var triggers: Array<Trigger> = [];
                 var paginationKey = (<any>res).body.nextPaginationKey ? (<any>res).body.nextPaginationKey : null;
                 for (var json of (<any>res).body.triggers) {
-                    triggers.push(Trigger.fromJson(json));
+                    triggers.push(JsonUtils.jsonToTrigger(json));
                 }
                 resolve(new QueryResult(triggers, paginationKey))
             }).catch((err)=>{

--- a/src/ops/TriggerOps.ts
+++ b/src/ops/TriggerOps.ts
@@ -19,6 +19,8 @@ import {TypedID} from '../TypedID'
 import {Command} from '../Command'
 import {ServerCodeResult} from '../ServerCodeResult'
 import * as KiiUtil from '../internal/KiiUtilities'
+import * as JsonUtils from '../internal/JsonUtilities'
+import { triggeredCommandToJson } from '../internal/JsonUtilities';
 
 export default class TriggerOps extends BaseOp {
     constructor(
@@ -59,18 +61,10 @@ export default class TriggerOps extends BaseOp {
                 commandTarget = commandRequest.targetID;
             }
 
-            var command = new Command(
-                commandTarget,
-                commandRequest.issuerID,
-                commandRequest.aliasActions);
-            command.title = commandRequest.title;
-            command.description = commandRequest.description;
-            command.metadata = commandRequest.metadata;
-
             var requestBody: any = {
                 predicate: requestObject.predicate.toJson(),
                 triggersWhat: TriggersWhat.COMMAND,
-                command: command.toJson()
+                command: JsonUtils.triggeredCommandToJson(commandRequest)
             }
 
             if(!!requestObject.title){
@@ -84,6 +78,14 @@ export default class TriggerOps extends BaseOp {
             if(!!requestObject.metadata){
                 requestBody["metadata"] = requestObject.metadata;
             }
+
+            var command = new Command(
+                commandTarget,
+                commandRequest.issuerID,
+                commandRequest.aliasActions);
+            command.title = commandRequest.title;
+            command.description = commandRequest.description;
+            command.metadata = commandRequest.metadata;
 
             this.postTrigger(requestBody).then((res:Response)=>{
                 var trigger = new Trigger(requestObject.predicate, command, null);
@@ -213,14 +215,7 @@ export default class TriggerOps extends BaseOp {
                     reject(new ThingIFError(Errors.ArgumentError, "issuerID is null"));
                     return;
                 }
-                var command = new Command(
-                    commandRequest.targetID,
-                    commandRequest.issuerID,
-                    commandRequest.aliasActions);
-                command.title = commandRequest.title;
-                command.description = commandRequest.description;
-                command.metadata = commandRequest.metadata;
-                requestBody["command"] = command.toJson();
+                requestBody["command"] = JsonUtils.triggeredCommandToJson(commandRequest);
                 requestBody["triggersWhat"] = "COMMAND";
             }
             if(!!requestObject.title){

--- a/test/small/JsonUtilitiesTest.ts
+++ b/test/small/JsonUtilitiesTest.ts
@@ -1,8 +1,10 @@
 import { expect } from 'chai';
-import { actionToJson, jsonToAction, aliasActionToJson, jsonToAliasAction, jsonToActionResult, jsonToAliasActionResult, triggerClauseToJson, jsonToTriggerClause } from '../../src/internal/JsonUtilities';
+import { actionToJson, jsonToAction, aliasActionToJson, jsonToAliasAction, jsonToActionResult, jsonToAliasActionResult, triggerClauseToJson, jsonToTriggerClause, triggeredCommandToJson, jsonToTrigger } from '../../src/internal/JsonUtilities';
 import { Action, AliasAction } from '../../src/AliasAction';
 import { ActionResult, AliasActionResult } from '../../src/AliasActionResult';
 import { EqualsClauseInTrigger, NotEqualsClauseInTrigger, RangeClauseInTrigger, AndClauseInTrigger, OrClauseInTrigger } from '../../src/TriggerClause';
+import { TriggerCommandObject } from '../../src/RequestObjects';
+import { TypedID, Types } from '../../src/TypedID';
 
 describe('Test JsonUtilities', () => {
     it('Test actionToJson()', () => {
@@ -350,4 +352,46 @@ describe('Test JsonUtilities for TriggerClause', () => {
         });
     })
 
+})
+
+describe('Test JsonUtilities for Trigger', () => {
+    describe("Test triggeredCommandToJson()", () => {
+        it("provide with invalid parameters should return null", () => {
+            expect(triggeredCommandToJson(new TriggerCommandObject(null))).null;
+            expect(triggeredCommandToJson(new TriggerCommandObject(
+                [new AliasAction("alias", [new Action("turnPower", true)])],
+                null,
+                null
+            ))).null;
+            expect(triggeredCommandToJson(new TriggerCommandObject(
+                [new AliasAction("alias", [new Action("turnPower", true)])],
+                new TypedID(Types.Thing, "thing-1"),
+                null
+            ))).null;
+            expect(triggeredCommandToJson(new TriggerCommandObject(
+                [new AliasAction("alias", [new Action("turnPower", true)])],
+                null,
+                new TypedID(Types.User, "user-1")
+            ))).null;
+        })
+        it("provide with parameters, json should be returned as expection", () => {
+            expect(triggeredCommandToJson(new TriggerCommandObject(
+                [new AliasAction("alias", [new Action("turnPower", true)])],
+                new TypedID(Types.Thing, "thing-1"),
+                new TypedID(Types.User, "user-1"),
+                "title",
+                "description",
+                {key: "value"}
+            ))).deep.equal({
+                actions: [
+                    {alias: [{turnPower: true}]}
+                ],
+                target: "thing:thing-1",
+                issuer: "user:user-1",
+                title: "title",
+                description: "description",
+                metadata: {key: "value"}
+            })
+        })
+    })
 })

--- a/test/small/TriggerOpsTest.ts
+++ b/test/small/TriggerOpsTest.ts
@@ -21,21 +21,24 @@ import {Trigger, TriggersWhen, TriggersWhat} from '../../src/Trigger';
 import {Command, CommandState} from '../../src/Command';
 import {Predicate, StatePredicate, SchedulePredicate, ScheduleOncePredicate, EventSource} from '../../src/Predicate';
 import {Condition} from '../../src/Condition';
-import {Clause, Equals, NotEquals, Range, And, Or} from '../../src/Clause';
 import {ServerCode} from '../../src/ServerCode';
 import {ServerCodeResult} from '../../src/ServerCodeResult';
 import {QueryResult} from '../../src/QueryResult';
 import {ThingIFError, HttpRequestError, Errors} from '../../src/ThingIFError';
 import * as TestUtil from './utils/TestUtil'
+import { EqualsClauseInTrigger } from '../../src/TriggerClause';
+import { AliasAction, Action } from '../../src/AliasAction';
+import { Logger, LogLevel } from '../../src/Logger';
 let testApp = new TestApp();
 let ownerToken = "4qxjayegngnfcq3f8sw7d9l0e9fleffd";
 let owner = new TypedID(Types.User, "userid-01234");
 let target = new TypedID(Types.Thing, "th.01234-abcde");
 let au = new APIAuthor(ownerToken, testApp.app);
+Logger.getInstance().setLogLevel(LogLevel.Debug);
 let triggerOps = new TriggerOps(au, target);
 let commandTarget = new TypedID(Types.Thing, "th.2355-eftef");
 
-describe('Test TriggerOps', function () {
+describe('Test TriggerOps', () => {
 
     beforeEach(function() {
         nock.cleanAll();
@@ -44,8 +47,29 @@ describe('Test TriggerOps', function () {
     let expectedTriggerID = "46bc25c0-4f12-11e6-ae54-22000ad9164c";
     let schema = "LED";
     let schemaVersion = 1;
-    let actions = [{turnPower: {power:true}}, {setColor: {color: [255,0,255]}}];
-    let condition = new Condition(new Equals("power", "false"));
+    let actions = [
+        new AliasAction("alias1", [
+            new Action("turnPower", true),
+            new Action("setPresetTemp", 23)
+        ]),
+        new AliasAction("alias2", [
+            new Action("setPresetHum", 45)
+        ])
+    ];
+    let jsonActions = [
+        {
+            alias1: [
+                {turnPower: true},
+                {setPresetTemp: 23}
+            ],
+        },
+        {
+            alias2: [
+                {setPresetHum: 45}
+            ]
+        }
+    ]
+    let condition = new Condition(new EqualsClauseInTrigger("alias1", "power", "false"));
     let statePredicate = new StatePredicate(condition, TriggersWhen.CONDITION_CHANGED);
     let schedulePredicate = new SchedulePredicate("0 12 1 * *");
     let scheduleOncePredicate = new ScheduleOncePredicate(1469089120402);
@@ -54,17 +78,15 @@ describe('Test TriggerOps', function () {
         "predicate":{
             "triggersWhen":"CONDITION_CHANGED",
             "condition":{
-                "type":"eq","field":"power","value":"false"
+                "type":"eq","alias": "alias1","field":"power","value":"false"
             },
             "eventSource":"STATES"
         },
         "triggersWhat":"COMMAND",
         "command":{
-            "schema": schema,
-            "schemaVersion": schemaVersion,
             "target": target.toString(),
             "issuer": owner.toString(),
-            "actions": actions
+            "actions": jsonActions
         },
         "disabled":false
     }
@@ -76,11 +98,9 @@ describe('Test TriggerOps', function () {
         },
         "triggersWhat":"COMMAND",
         "command":{
-            "schema": schema,
-            "schemaVersion": schemaVersion,
             "target": target.toString(),
             "issuer": owner.toString(),
-            "actions": actions
+            "actions": jsonActions
         },
         "disabled":false
     }
@@ -92,11 +112,9 @@ describe('Test TriggerOps', function () {
         },
         "triggersWhat":"COMMAND",
         "command":{
-            "schema": schema,
-            "schemaVersion": schemaVersion,
             "target": target.toString(),
             "issuer": owner.toString(),
-            "actions": actions
+            "actions": jsonActions
         },
         "disabled":false
     }
@@ -108,7 +126,7 @@ describe('Test TriggerOps', function () {
         "predicate":{
             "triggersWhen":"CONDITION_CHANGED",
             "condition":{
-                "type":"eq","field":"power","value":"false"
+               "alias": "alias1", "type":"eq","field":"power","value":"false"
             },
             "eventSource":"STATES"
         },
@@ -152,10 +170,10 @@ describe('Test TriggerOps', function () {
         "disabled":false
     }
 
-    describe('#postCommandTrigger() with promise', function () {
+    describe('#postCommandTrigger() with promise', () => {
         let postCommandTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers`;
-        let commandRequest = new TriggerCommandObject(schema, schemaVersion, actions, target, owner);
-        it("with StatePredicate", function (done) {
+        let commandRequest = new TriggerCommandObject(actions, target, owner);
+        it("with StatePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -164,22 +182,23 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).post(postCommandTriggerPath, {
-                    "predicate":{
-                        "triggersWhen":"CONDITION_CHANGED",
-                        "condition":{
-                            "type":"eq","field":"power","value":"false"
+                }).post(postCommandTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
+                        "predicate":{
+                            "triggersWhen":"CONDITION_CHANGED",
+                            "condition":{
+                                "type":"eq","alias": "alias1", "field":"power","value":"false"
+                            },
+                            "eventSource":"STATES"
                         },
-                        "eventSource":"STATES"
-                    },
-                    "triggersWhat":"COMMAND",
-                    "command":{
-                        "schema": schema,
-                        "schemaVersion": schemaVersion,
-                        "target": target.toString(),
-                        "issuer": owner.toString(),
-                        "actions": actions
-                    }
+                        "triggersWhat":"COMMAND",
+                        "command":{
+                            "target": target.toString(),
+                            "issuer": owner.toString(),
+                            "actions": jsonActions
+                        }
+                    });
+                    return true;
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
             let request = new PostCommandTriggerRequest(commandRequest, statePredicate);
@@ -190,9 +209,7 @@ describe('Test TriggerOps', function () {
                     expect(trigger.predicate.getEventSource()).to.equal("STATES");
                     expect((<StatePredicate>trigger.predicate).triggersWhen).to.equal("CONDITION_CHANGED");
                     expect((<StatePredicate>trigger.predicate).condition).to.deep.equal(condition);
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(target);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -204,7 +221,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("with SchedulePredicate", function (done) {
+        it("with SchedulePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -213,19 +230,20 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).post(postCommandTriggerPath, {
-                    "predicate":{
-                        "schedule":"0 12 1 * *",
-                        "eventSource":"SCHEDULE"
-                    },
-                    "triggersWhat":"COMMAND",
-                    "command":{
-                        "schema": schema,
-                        "schemaVersion": schemaVersion,
-                        "target": target.toString(),
-                        "issuer": owner.toString(),
-                        "actions": actions
-                    }
+                }).post(postCommandTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
+                        "predicate":{
+                            "schedule":"0 12 1 * *",
+                            "eventSource":"SCHEDULE"
+                        },
+                        "triggersWhat":"COMMAND",
+                        "command":{
+                            "target": target.toString(),
+                            "issuer": owner.toString(),
+                            "actions": jsonActions
+                        }
+                    });
+                    return true;
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
 
@@ -236,9 +254,7 @@ describe('Test TriggerOps', function () {
                     expect(trigger.disabled).to.be.false;
                     expect(trigger.predicate.getEventSource()).to.equal("SCHEDULE");
                     expect((<SchedulePredicate>trigger.predicate).schedule).to.equal("0 12 1 * *");
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(target);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -250,7 +266,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("with ScheduleOncePredicate", function (done) {
+        it("with ScheduleOncePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -259,19 +275,20 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).post(postCommandTriggerPath, {
+                }).post(postCommandTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "scheduleAt": 1469089120402,
                         "eventSource":"SCHEDULE_ONCE"
                     },
                     "triggersWhat":"COMMAND",
                     "command":{
-                        "schema": schema,
-                        "schemaVersion": schemaVersion,
                         "target": target.toString(),
                         "issuer": owner.toString(),
-                        "actions": actions
+                        "actions": jsonActions
                     }
+                    });
+                    return true;
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
 
@@ -282,9 +299,7 @@ describe('Test TriggerOps', function () {
                     expect(trigger.disabled).to.be.false;
                     expect(trigger.predicate.getEventSource()).to.equal("SCHEDULE_ONCE");
                     expect((<ScheduleOncePredicate>trigger.predicate).scheduleAt).to.equal(1469089120402);
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(target);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -296,7 +311,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("handle error response", function (done) {
+        it("handle error response", (done) => {
             let errResponse = {
                 "errorCode": "WRONG_TRIGGER",
                 "message": "The provided trigger is not valid"
@@ -309,22 +324,23 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).post(postCommandTriggerPath, {
+                }).post(postCommandTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "triggersWhen":"CONDITION_CHANGED",
                         "condition":{
-                            "type":"eq","field":"power","value":"false"
+                            "alias": "alias1", "type":"eq","field":"power","value":"false"
                         },
                         "eventSource":"STATES"
                     },
                     "triggersWhat":"COMMAND",
                     "command":{
-                        "schema": schema,
-                        "schemaVersion": schemaVersion,
                         "target": target.toString(),
                         "issuer": owner.toString(),
-                        "actions": actions
+                        "actions": jsonActions
                     }
+                    });
+                    return true;
                 })
                 .reply(400, errResponse, {"Content-Type": "application/json"});
 
@@ -352,12 +368,8 @@ describe('Test TriggerOps', function () {
             let predicate = new ScheduleOncePredicate(new Date().getTime());
             let tests = [
                 new TestCase(null, Errors.ArgumentError, "requestObject is null", "should handle error when requestObject is null"),
-                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject(null, 1, [{turnPower: {power:true}}], target, owner), predicate), Errors.ArgumentError, "schema of command is null or empty", "should handle error when schema is null"),
-                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("", 1, [{turnPower: {power:true}}], target, owner), predicate), Errors.ArgumentError, "schema of command is null or empty", "should handle error when schema is empty"),
-                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", null, [{turnPower: {power:true}}], target, owner), predicate), Errors.ArgumentError, "schemaVersion of command is null", "should handle error when schemaVersion is null"),
-                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, null, target, owner), predicate), Errors.ArgumentError, "actions of command is null", "should handle error when actions is null"),
-                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], target, owner), null), Errors.ArgumentError, "predicate is null", "should handle error when predicate is null"),
-                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], target, null), predicate), Errors.ArgumentError, "issuerID of command is null", "should handle error when issuerID is null"),
+                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject([new AliasAction("alias1", [new Action("turnPower", true)])], target, owner), null), Errors.ArgumentError, "predicate is null", "should handle error when predicate is null"),
+                new TestCase(new PostCommandTriggerRequest(new TriggerCommandObject([new AliasAction("alias1", [new Action("turnPower", true)])], target, null), predicate), Errors.ArgumentError, "issuerID of command is null", "should handle error when issuerID is null"),
                 new TestCase(new PostCommandTriggerRequest(null, predicate), Errors.ArgumentError, "command is null", "should handle error when command is null"),
             ]
             tests.forEach(function(test) {
@@ -378,11 +390,11 @@ describe('Test TriggerOps', function () {
             });
         });
     });
-    describe('#postCommandTrigger() with promise(cross thing command trigger)', function () {
+    describe('#postCommandTrigger() with promise(cross thing command trigger)', () => {
         let postCommandTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers`;
-        let commandRequest = new TriggerCommandObject(schema, schemaVersion, actions, commandTarget, owner);
+        let commandRequest = new TriggerCommandObject(actions, commandTarget, owner);
 
-        it("with StatePredicate", function (done) {
+        it("with StatePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -391,22 +403,23 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).post(postCommandTriggerPath, {
+                }).post(postCommandTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "triggersWhen":"CONDITION_CHANGED",
                         "condition":{
-                            "type":"eq","field":"power","value":"false"
+                            "alias": "alias1", "type":"eq","field":"power","value":"false"
                         },
                         "eventSource":"STATES"
                     },
                     "triggersWhat":"COMMAND",
                     "command":{
-                        "schema": schema,
-                        "schemaVersion": schemaVersion,
                         "target": commandTarget.toString(),
                         "issuer": owner.toString(),
-                        "actions": actions
+                        "actions": jsonActions
                     }
+                    });
+                    return true;
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
 
@@ -418,9 +431,7 @@ describe('Test TriggerOps', function () {
                     expect(trigger.predicate.getEventSource()).to.equal("STATES");
                     expect((<StatePredicate>trigger.predicate).triggersWhen).to.equal("CONDITION_CHANGED");
                     expect((<StatePredicate>trigger.predicate).condition).to.deep.equal(condition);
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(commandTarget);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -433,9 +444,9 @@ describe('Test TriggerOps', function () {
             });
         });
     });
-    describe('#postServerCodeTriggger() with promise', function () {
+    describe('#postServerCodeTriggger() with promise', () => {
         let postServerCodeTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers`;
-        it("with StatePredicate", function (done) {
+        it("with StatePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -444,11 +455,12 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).post(postServerCodeTriggerPath, {
+                }).post(postServerCodeTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "triggersWhen":"CONDITION_CHANGED",
                         "condition":{
-                            "type":"eq","field":"power","value":"false"
+                            "alias": "alias1", "type":"eq","field":"power","value":"false"
                         },
                         "eventSource":"STATES"
                     },
@@ -459,6 +471,8 @@ describe('Test TriggerOps', function () {
                         "executorAccessToken" : ownerToken,
                         "targetAppID": testApp.appID
                     }
+                    });
+                    return true;
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
 
@@ -483,7 +497,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("with SchedulePredicate", function (done) {
+        it("with SchedulePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -492,7 +506,8 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).post(postServerCodeTriggerPath, {
+                }).post(postServerCodeTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "schedule":"0 12 1 * *",
                         "eventSource":"SCHEDULE"
@@ -504,6 +519,8 @@ describe('Test TriggerOps', function () {
                         "executorAccessToken" : ownerToken,
                         "targetAppID": testApp.appID
                     }
+                    });
+                    return true;
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
 
@@ -527,7 +544,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("with ScheduleOncePredicate", function (done) {
+        it("with ScheduleOncePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -536,7 +553,8 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).post(postServerCodeTriggerPath, {
+                }).post(postServerCodeTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "scheduleAt": 1469089120402,
                         "eventSource":"SCHEDULE_ONCE"
@@ -548,6 +566,8 @@ describe('Test TriggerOps', function () {
                         "executorAccessToken" : ownerToken,
                         "targetAppID": testApp.appID
                     }
+                    });
+                    return true;
                 })
                 .reply(201, {triggerID: expectedTriggerID}, {"Content-Type": "application/json"});
 
@@ -571,7 +591,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("handle error response", function (done) {
+        it("handle error response", (done) => {
             let errResponse = {
                 "errorCode": "WRONG_TRIGGER",
                 "message": "The provided trigger is not valid"
@@ -584,11 +604,12 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).post(postServerCodeTriggerPath, {
+                }).post(postServerCodeTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "triggersWhen":"CONDITION_CHANGED",
                         "condition":{
-                            "type":"eq","field":"power","value":"false"
+                            "alias": "alias1", "type":"eq","field":"power","value":"false"
                         },
                         "eventSource":"STATES"
                     },
@@ -599,6 +620,8 @@ describe('Test TriggerOps', function () {
                         "executorAccessToken" : ownerToken,
                         "targetAppID": testApp.appID
                     }
+                    });
+                    return true;
                 })
                 .reply(400, errResponse, {"Content-Type": "application/json"});
 
@@ -648,14 +671,14 @@ describe('Test TriggerOps', function () {
             });
         });
     });
-    describe('#patchCommandTrigger() with promise', function () {
+    describe('#patchCommandTrigger() with promise', () => {
         // patchCommandTrigger method sends request to server twice.
         // 1. PATCH `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`
         // 2. GET  `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`
         let patchCommandTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`;
         let getTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`;
-        let commandRequest = new TriggerCommandObject(schema, schemaVersion, actions, target, owner);
-        it("with StatePredicate", function (done) {
+        let commandRequest = new TriggerCommandObject(actions, target, owner);
+        it("with StatePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -664,22 +687,23 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).patch(patchCommandTriggerPath, {
+                }).patch(patchCommandTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "triggersWhen":"CONDITION_CHANGED",
                         "condition":{
-                            "type":"eq","field":"power","value":"false"
+                            "alias": "alias1", "type":"eq","field":"power","value":"false"
                         },
                         "eventSource":"STATES"
                     },
                     "triggersWhat":"COMMAND",
                     "command":{
-                        "schema": schema,
-                        "schemaVersion": schemaVersion,
                         "target": target.toString(),
                         "issuer": owner.toString(),
-                        "actions": actions
+                        "actions": jsonActions
                     }
+                    });
+                    return true;
                 })
                 .reply(204, null);
             nock(
@@ -695,14 +719,13 @@ describe('Test TriggerOps', function () {
             let request = new PatchCommandTriggerRequest(commandRequest, statePredicate);
             triggerOps.patchCommandTrigger(expectedTriggerID, request).then((trigger:Trigger)=>{
                 try {
+                    expect(trigger).not.null;
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
                     expect(trigger.disabled).to.be.false;
                     expect(trigger.predicate.getEventSource()).to.equal("STATES");
                     expect((<StatePredicate>trigger.predicate).triggersWhen).to.equal("CONDITION_CHANGED");
                     expect((<StatePredicate>trigger.predicate).condition).to.deep.equal(condition);
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(target);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -714,7 +737,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("with SchedulePredicate", function (done) {
+        it("with SchedulePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -730,11 +753,9 @@ describe('Test TriggerOps', function () {
                     },
                     "triggersWhat":"COMMAND",
                     "command":{
-                        "schema": schema,
-                        "schemaVersion": schemaVersion,
                         "target": target.toString(),
                         "issuer": owner.toString(),
-                        "actions": actions
+                        "actions": jsonActions
                     }
                 })
                 .reply(204, null);
@@ -755,9 +776,7 @@ describe('Test TriggerOps', function () {
                     expect(trigger.disabled).to.be.false;
                     expect(trigger.predicate.getEventSource()).to.equal("SCHEDULE");
                     expect((<SchedulePredicate>trigger.predicate).schedule).to.equal("0 12 1 * *");
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(target);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -769,7 +788,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("with ScheduleOncePredicate", function (done) {
+        it("with ScheduleOncePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -778,19 +797,20 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).patch(patchCommandTriggerPath, {
+                }).patch(patchCommandTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "scheduleAt": 1469089120402,
                         "eventSource":"SCHEDULE_ONCE"
                     },
                     "triggersWhat":"COMMAND",
                     "command":{
-                        "schema": schema,
-                        "schemaVersion": schemaVersion,
                         "target": target.toString(),
                         "issuer": owner.toString(),
-                        "actions": actions
+                        "actions": jsonActions
                     }
+                    });
+                    return true;
                 })
                 .reply(204, null);
             nock(
@@ -810,9 +830,7 @@ describe('Test TriggerOps', function () {
                     expect(trigger.disabled).to.be.false;
                     expect(trigger.predicate.getEventSource()).to.equal("SCHEDULE_ONCE");
                     expect((<ScheduleOncePredicate>trigger.predicate).scheduleAt).to.equal(1469089120402);
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(target);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -824,7 +842,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("handle error response", function (done) {
+        it("handle error response", (done) => {
             let errResponse = {
                 "errorCode": "WRONG_TRIGGER",
                 "message": "The provided trigger is not valid"
@@ -837,22 +855,23 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).patch(patchCommandTriggerPath, {
+                }).patch(patchCommandTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "triggersWhen":"CONDITION_CHANGED",
                         "condition":{
-                            "type":"eq","field":"power","value":"false"
+                            "alias": "alias1", "type":"eq","field":"power","value":"false"
                         },
                         "eventSource":"STATES"
                     },
                     "triggersWhat":"COMMAND",
                     "command":{
-                        "schema": schema,
-                        "schemaVersion": schemaVersion,
                         "target": target.toString(),
                         "issuer": owner.toString(),
-                        "actions": actions
+                        "actions": jsonActions
                     }
+                    });
+                    return true;
                 })
                 .reply(400, errResponse, {"Content-Type": "application/json"});
 
@@ -880,13 +899,10 @@ describe('Test TriggerOps', function () {
             }
             let predicate = new ScheduleOncePredicate(new Date().getTime());
             let tests = [
-                new TestCase(null, new PatchCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], target), predicate), Errors.ArgumentError, "triggerID is null or empty", "should handle error when triggerID is null"),
-                new TestCase("", new PatchCommandTriggerRequest(new TriggerCommandObject("led", 1, [{turnPower: {power:true}}], target), predicate), Errors.ArgumentError, "triggerID is null or empty", "should handle error when triggerID is empty"),
+                new TestCase(null, new PatchCommandTriggerRequest(new TriggerCommandObject([new AliasAction("alias1", [new Action("turnPower", true)])], target), predicate), Errors.ArgumentError, "triggerID is null or empty", "should handle error when triggerID is null"),
+                new TestCase("", new PatchCommandTriggerRequest(new TriggerCommandObject([new AliasAction("alias1", [new Action("turnPower", true)])], target), predicate), Errors.ArgumentError, "triggerID is null or empty", "should handle error when triggerID is empty"),
                 new TestCase("trigger-01234-abcd", null, Errors.ArgumentError, "requestObject is null", "should handle error when requestObject is null"),
-                new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject(null, 1, [{turnPower: {power:true}}], target), predicate), Errors.ArgumentError, "schema of command is null or empty", "should handle error when schema is null"),
-                new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject("", 1, [{turnPower: {power:true}}], target), predicate), Errors.ArgumentError, "schema of command is null or empty", "should handle error when schema is empty"),
-                new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject("led", null, [{turnPower: {power:true}}], target), predicate), Errors.ArgumentError, "schemaVersion of command is null", "should handle error when schemaVersion is null"),
-                new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject("led", 1, null, target), null), Errors.ArgumentError, "actions of command is null", "should handle error when actions and predicate are null"),
+                new TestCase("trigger-01234-abcd", new PatchCommandTriggerRequest(new TriggerCommandObject(null, target), null), Errors.ArgumentError, "aliasActions of command is null", "should handle error when actions and predicate are null"),
             ]
             tests.forEach(function(test) {
                 it(test.description, function(done){
@@ -907,7 +923,7 @@ describe('Test TriggerOps', function () {
         });
     });
 
-    describe('#patchCommandTrigger() with promise(cross thing command trigger)', function () {
+    describe('#patchCommandTrigger() with promise(cross thing command trigger)', () => {
         // patchCommandTrigger method sends request to server twice.
         // 1. PATCH `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`
         // 2. GET  `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`
@@ -918,21 +934,19 @@ describe('Test TriggerOps', function () {
         "predicate":{
             "triggersWhen":"CONDITION_CHANGED",
             "condition":{
-                "type":"eq","field":"power","value":"false"
+                "alias": "alias1", "type":"eq","field":"power","value":"false"
             },
             "eventSource":"STATES"
         },
         "triggersWhat":"COMMAND",
         "command":{
-            "schema": schema,
-            "schemaVersion": schemaVersion,
             "target": commandTarget.toString(),
             "issuer": owner.toString(),
-            "actions": actions
+            "actions": jsonActions
         },
         "disabled":false
     }
-        it("with StatePredicate", function (done) {
+        it("with StatePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -941,22 +955,23 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).patch(patchCommandTriggerPath, {
+                }).patch(patchCommandTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "triggersWhen":"CONDITION_CHANGED",
                         "condition":{
-                            "type":"eq","field":"power","value":"false"
+                            "alias": "alias1", "type":"eq","field":"power","value":"false"
                         },
                         "eventSource":"STATES"
                     },
                     "triggersWhat":"COMMAND",
                     "command":{
-                        "schema": schema,
-                        "schemaVersion": schemaVersion,
                         "target": commandTarget.toString(),
                         "issuer": owner.toString(),
-                        "actions": actions
+                        "actions": jsonActions
                     }
+                    });
+                    return true;
                 })
                 .reply(204, null);
             nock(
@@ -969,7 +984,7 @@ describe('Test TriggerOps', function () {
                 }).get(getTriggerPath)
                 .reply(200, responseBody4CrossThingCommandTriggerWithState, {"Content-Type": "application/json"});
 
-            let request = new PatchCommandTriggerRequest(new TriggerCommandObject(schema, schemaVersion, actions, commandTarget, owner), statePredicate);
+            let request = new PatchCommandTriggerRequest(new TriggerCommandObject(actions, commandTarget, owner), statePredicate);
             triggerOps.patchCommandTrigger(expectedTriggerID, request).then((trigger:Trigger)=>{
                 try {
                     expect(trigger.triggerID).to.equal(expectedTriggerID);
@@ -977,9 +992,7 @@ describe('Test TriggerOps', function () {
                     expect(trigger.predicate.getEventSource()).to.equal("STATES");
                     expect((<StatePredicate>trigger.predicate).triggersWhen).to.equal("CONDITION_CHANGED");
                     expect((<StatePredicate>trigger.predicate).condition).to.deep.equal(condition);
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(commandTarget);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -992,13 +1005,13 @@ describe('Test TriggerOps', function () {
             });
         });
     });
-    describe('#patchServerCodeTrigger() with promise', function () {
+    describe('#patchServerCodeTrigger() with promise', () => {
         // patchServerCodeTrigger method sends request to server twice.
         // 1. PATCH `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`
         // 2. GET  `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`
         let patchServerCodeTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`;
         let getTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`;
-        it("with StatePredicate", function (done) {
+        it("with StatePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -1007,11 +1020,12 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).patch(patchServerCodeTriggerPath, {
+                }).patch(patchServerCodeTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "triggersWhen":"CONDITION_CHANGED",
                         "condition":{
-                            "type":"eq","field":"power","value":"false"
+                            "alias": "alias1", "type":"eq","field":"power","value":"false"
                         },
                         "eventSource":"STATES"
                     },
@@ -1022,6 +1036,8 @@ describe('Test TriggerOps', function () {
                         "executorAccessToken" : ownerToken,
                         "targetAppID": testApp.appID
                     }
+                    });
+                    return true;
                 })
                 .reply(204, null);
             nock(
@@ -1055,7 +1071,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("with SchedulePredicate", function (done) {
+        it("with SchedulePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -1064,7 +1080,8 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).patch(patchServerCodeTriggerPath, {
+                }).patch(patchServerCodeTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "schedule":"0 12 1 * *",
                         "eventSource":"SCHEDULE"
@@ -1076,6 +1093,8 @@ describe('Test TriggerOps', function () {
                         "executorAccessToken" : ownerToken,
                         "targetAppID": testApp.appID
                     }
+                    });
+                    return true;
                 })
                 .reply(204, null);
             nock(
@@ -1108,7 +1127,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("with ScheduleOncePredicate", function (done) {
+        it("with ScheduleOncePredicate", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -1117,7 +1136,8 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).patch(patchServerCodeTriggerPath, {
+                }).patch(patchServerCodeTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "scheduleAt": 1469089120402,
                         "eventSource":"SCHEDULE_ONCE"
@@ -1129,6 +1149,8 @@ describe('Test TriggerOps', function () {
                         "executorAccessToken" : ownerToken,
                         "targetAppID": testApp.appID
                     }
+                    });
+                    return true;
                 })
                 .reply(204, null);
             nock(
@@ -1161,7 +1183,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("handle error response", function (done) {
+        it("handle error response", (done) => {
             let errResponse = {
                 "errorCode": "WRONG_TRIGGER",
                 "message": "The provided trigger is not valid"
@@ -1174,11 +1196,12 @@ describe('Test TriggerOps', function () {
                         "Authorization":"Bearer " + ownerToken,
                         "Content-Type": "application/json"
                     }
-                }).patch(patchServerCodeTriggerPath, {
+                }).patch(patchServerCodeTriggerPath, (body: any) => {
+                    expect(body).deep.equal({
                     "predicate":{
                         "triggersWhen":"CONDITION_CHANGED",
                         "condition":{
-                            "type":"eq","field":"power","value":"false"
+                            "alias": "alias1", "type":"eq","field":"power","value":"false"
                         },
                         "eventSource":"STATES"
                     },
@@ -1189,6 +1212,8 @@ describe('Test TriggerOps', function () {
                         "executorAccessToken" : ownerToken,
                         "targetAppID": testApp.appID
                     }
+                    });
+                    return true;
                 })
                 .reply(400, errResponse, {"Content-Type": "application/json"});
 
@@ -1240,8 +1265,8 @@ describe('Test TriggerOps', function () {
             });
         });
     });
-    describe('#enableTrigger() with promise', function () {
-        it("to enable", function (done) {
+    describe('#enableTrigger() with promise', () => {
+        it("to enable", (done) => {
             // enableTrigger method sends request to server twice.
             // 1. PUT `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}/enable`
             // 2. GET  `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`
@@ -1274,9 +1299,7 @@ describe('Test TriggerOps', function () {
                     expect(trigger.predicate.getEventSource()).to.equal("STATES");
                     expect((<StatePredicate>trigger.predicate).triggersWhen).to.equal("CONDITION_CHANGED");
                     expect((<StatePredicate>trigger.predicate).condition).to.deep.equal(condition);
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(target);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -1288,7 +1311,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("to disable", function (done) {
+        it("to disable", (done) => {
             // enableTrigger method sends request to server twice.
             // 1. PUT `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}/disable`
             // 2. GET  `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`
@@ -1321,9 +1344,7 @@ describe('Test TriggerOps', function () {
                     expect(trigger.predicate.getEventSource()).to.equal("STATES");
                     expect((<StatePredicate>trigger.predicate).triggersWhen).to.equal("CONDITION_CHANGED");
                     expect((<StatePredicate>trigger.predicate).condition).to.deep.equal(condition);
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(target);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -1335,7 +1356,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("handle error response", function (done) {
+        it("handle error response", (done) => {
             let errResponse = {
                 "errorCode": "TRIGGER_NOT_FOUND",
                 "message": "The trigger is not found"
@@ -1396,8 +1417,8 @@ describe('Test TriggerOps', function () {
             });
         });
     });
-    describe('#deleteTrigger() with promise', function () {
-        it("should send a request to the thing-if server", function (done) {
+    describe('#deleteTrigger() with promise', () => {
+        it("should send a request to the thing-if server", (done) => {
             let deleteTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`;
             nock(
                 testApp.site,
@@ -1420,7 +1441,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("handle error response", function (done) {
+        it("handle error response", (done) => {
             let errResponse = {
                 "errorCode": "TRIGGER_NOT_FOUND",
                 "message": "The trigger is not found"
@@ -1478,14 +1499,14 @@ describe('Test TriggerOps', function () {
             });
         });
     });
-    describe('#getTrigger() with promise', function () {
+    describe('#getTrigger() with promise', () => {
         let getTriggerPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}`;
-        it("should send a request to the thing-if server", function (done) {
+        it("should send a request to the thing-if server", (done) => {
             // getTrigger() method is used by other methods internally.
             // So we can skip small test for getTrigger() method.
             done();
         });
-        it("handle error response", function (done) {
+        it("handle error response", (done) => {
             let errResponse = {
                 "errorCode": "TRIGGER_NOT_FOUND",
                 "message": "The trigger is not found"
@@ -1542,7 +1563,7 @@ describe('Test TriggerOps', function () {
             });
         });
     });
-    describe('#listTriggers() with promise', function () {
+    describe('#listTriggers() with promise', () => {
         let paginationKey = "1/2"
         let responseBody4ListTriggers1 = {
             triggers: [
@@ -1560,7 +1581,7 @@ describe('Test TriggerOps', function () {
             ]
         }
         let listTriggersPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers`;
-        it("with bestEffortLimit", function (done) {
+        it("with bestEffortLimit", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -1617,7 +1638,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("with pagination", function (done) {
+        it("with pagination", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -1648,9 +1669,7 @@ describe('Test TriggerOps', function () {
                     expect(trigger.predicate.getEventSource()).to.equal("STATES");
                     expect((<StatePredicate>trigger.predicate).triggersWhen).to.equal("CONDITION_CHANGED");
                     expect((<StatePredicate>trigger.predicate).condition).to.deep.equal(condition);
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(target);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -1660,9 +1679,7 @@ describe('Test TriggerOps', function () {
                     expect(trigger.disabled).to.be.false;
                     expect(trigger.predicate.getEventSource()).to.equal("SCHEDULE");
                     expect((<SchedulePredicate>trigger.predicate).schedule).to.equal("0 12 1 * *");
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(target);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -1672,9 +1689,7 @@ describe('Test TriggerOps', function () {
                     expect(trigger.disabled).to.be.false;
                     expect(trigger.predicate.getEventSource()).to.equal("SCHEDULE_ONCE");
                     expect((<ScheduleOncePredicate>trigger.predicate).scheduleAt).to.equal(1469089120402);
-                    expect(trigger.command.schema).to.equal(schema);
-                    expect(trigger.command.schemaVersion).to.equal(schemaVersion);
-                    expect(trigger.command.actions).to.deep.equal(actions);
+                    expect(trigger.command.aliasActions).to.deep.equal(actions);
                     expect(trigger.command.targetID).to.deep.equal(target);
                     expect(trigger.command.issuerID).to.deep.equal(owner);
                     expect(trigger.serverCode).to.be.null;
@@ -1728,7 +1743,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("handle error response", function (done) {
+        it("handle error response", (done) => {
             let errResponse = {
                 "errorCode": "WRONG_TOKEN",
                 "message": "The provided token is not valid"
@@ -1755,7 +1770,7 @@ describe('Test TriggerOps', function () {
             });
         });
     });
-    describe('#listServerCodeResults() with promise', function () {
+    describe('#listServerCodeResults() with promise', () => {
         let paginationKey = "1/2"
         let responseBody4ListServerCodeResults1 = {
             triggerServerCodeResults: [
@@ -1803,7 +1818,7 @@ describe('Test TriggerOps', function () {
             ]
         }
         let listServerCodeResultsPath = `/thing-if/apps/${testApp.appID}/targets/${target.toString()}/triggers/${expectedTriggerID}/results/server-code`;
-        it("with bestEffortLimit", function (done) {
+        it("with bestEffortLimit", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -1839,7 +1854,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("with pagination", function (done) {
+        it("with pagination", (done) => {
             nock(
                 testApp.site,
                 <any>{
@@ -1916,7 +1931,7 @@ describe('Test TriggerOps', function () {
                 done(err);
             });
         });
-        it("handle error response", function (done) {
+        it("handle error response", (done) => {
             let errResponse = {
                 "errorCode": "WRONG_TOKEN",
                 "message": "The provided token is not valid"


### PR DESCRIPTION
#### Main changes
- Fix TriggerOps
- Move small tests TriggerOpsTest.ts, and fix tests
- Move Trigger.fromJson to JsonUtilities as jsonToTrigger
- Remove Command.toJson, which only used in TriggerOps to convert command of trigger to json. The reason to remove is complete fields of command is not need to trigger. Only the fields of TriggeredCommandObject are necessary. 
- Add triggeredCommandToJson to convert command of trigger to json.
- Add small test to triggeredCommandToJson

#### Out of scope(will be in another PR):
- small test to jsonToTrigger
- move Predicate.fromJson to JsonUtilities
- move ServerCode.fromJson to JsonUtilities
